### PR TITLE
Fix lawmaker/committee matching so lawmaker pages display properly

### DIFF
--- a/inputs/lawmakers/committee-assignments-2025.csv
+++ b/inputs/lawmakers/committee-assignments-2025.csv
@@ -275,6 +275,8 @@ house-ethics,"Hawk, Donavon",vice-chair
 house-ethics,"Muszkiewicz, Luke",member
 joint-appropriations-section-a,"Falk, Terry",chair
 joint-appropriations-section-a,"Mandeville, Forrest",vice-chair
+joint-appropriations-section-a,"Ellsworth, Jason",member
+joint-appropriations-section-a,"Flowers, Pat",member
 joint-appropriations-section-a,"Harvey, Derek",member
 joint-appropriations-section-a,"Muszkiewicz, Luke",member
 joint-appropriations-section-a,"Tezak, Tony",member
@@ -285,7 +287,9 @@ joint-appropriations-section-b,"Lenz, Dennis",vice-chair
 joint-appropriations-section-b,"Caferro, Mary",member
 joint-appropriations-section-b,"Fox, Mike",member
 joint-appropriations-section-b,"Glimm, Carl",member
+joint-appropriations-section-b,"Kerr-Carpenter, Emma",member
 joint-appropriations-section-b,"Pope, Christopher",member
+joint-appropriations-section-b,"Tempel, Russ",member
 joint-appropriations-section-c,"Schillinger, Jerry",member
 joint-appropriations-section-c,"Cuffe, Mike",member
 joint-appropriations-section-c,"Albus, Eric",member
@@ -305,30 +309,37 @@ joint-appropriations-section-e,"Barker, Brad",member
 joint-appropriations-section-e,"Jones, Llew",member
 joint-appropriations-section-e,"Keogh, Connie",member
 joint-appropriations-section-e,"Matthews, Eric",member
+joint-appropriations-section-e,"Regier, Matt",member
 joint-appropriations-section-e,"Windy Boy, Jonathan",member
 joint-appropriations-section-f,"Fitzpatrick, John",chair
 joint-appropriations-section-f,"Esp, John",vice-chair
 joint-appropriations-section-f,"Boldman, Ellie",member
+joint-appropriations-section-f,"Kassmier, Josh",member
 joint-appropriations-section-f,"Rosenzweig, Scott",member
 joint-appropriations-section-f,"Tuss, Paul",member
 joint-appropriations-section-f,"Vinton, Mike",member
 senate-finance-and-claims,"Glimm, Carl",chair
 senate-finance-and-claims,"Esp, John",vice-chair
 senate-finance-and-claims,"Ellis, Janet",vice-chair
-senate-finance-and-claims,"Vance, Shelley",member
 senate-finance-and-claims,"Bogner, Kenneth",member
-senate-finance-and-claims,"Harvey, Derek",member
-senate-finance-and-claims,"Pope, Christopher",member
-senate-finance-and-claims,"Morigeau, Shane",member
-senate-finance-and-claims,"Windy Boy, Jonathan",member
 senate-finance-and-claims,"Boldman, Ellie",member
 senate-finance-and-claims,"Cuffe, Mike",member
+senate-finance-and-claims,"Ellsworth, Jason",member
+senate-finance-and-claims,"Flowers, Pat",member
 senate-finance-and-claims,"Fuller, John",member
+senate-finance-and-claims,"Harvey, Derek",member
+senate-finance-and-claims,"Kassmier, Josh",member
+senate-finance-and-claims,"Kerr-Carpenter, Emma",member
 senate-finance-and-claims,"Lenz, Dennis",member
 senate-finance-and-claims,"Mandeville, Forrest",member
 senate-finance-and-claims,"McGillvray, Tom",member
+senate-finance-and-claims,"Morigeau, Shane",member
+senate-finance-and-claims,"Pope, Christopher",member
 senate-finance-and-claims,"Regier, Matt",member
+senate-finance-and-claims,"Tempel, Russ",member
 senate-finance-and-claims,"Tezak, Tony",member
+senate-finance-and-claims,"Vance, Shelley",member
+senate-finance-and-claims,"Windy Boy, Jonathan",member
 senate-judiciary,"Usher, Barry",member
 senate-judiciary,"Ricci, Vince",member
 senate-judiciary,"Olsen, Andrea",member
@@ -342,16 +353,20 @@ senate-business-labor-and-economic-affairs,"Noland, Mark",chair
 senate-business-labor-and-economic-affairs,"Trebas, Jeremy",vice-chair
 senate-business-labor-and-economic-affairs,"Curdy, Willis",vice-chair
 senate-business-labor-and-economic-affairs,"Gillespie, Bruce ""Butch""",member
+senate-business-labor-and-economic-affairs,"Hunter, Greg,member
 senate-business-labor-and-economic-affairs,"Morigeau, Jacinda",member
 senate-business-labor-and-economic-affairs,"Novak, Sara",member
+senate-business-labor-and-economic-affairs,"Loge, Denley",member
 senate-business-labor-and-economic-affairs,"Phalen, Bob",member
+senate-business-labor-and-economic-affairs,"Webber, Susan",member
 senate-business-labor-and-economic-affairs,"Zolnikov, Daniel",member
 senate-taxation,"Hertz, Greg",chair
 senate-taxation,"Beard, Becky",vice-chair
 senate-taxation,"Fern, Dave",vice-chair
-senate-taxation,"Dunwell, Mary Ann",member
 senate-taxation,"Flowers, Pat",member
+senate-taxation,"Dunwell, Mary Ann",member
 senate-taxation,"Galt, Wylie",member
+senate-taxation,"Hayman, Denise",member
 senate-taxation,"McKamey, Wendy",member
 senate-taxation,"Yakawich, Mike",member
 senate-education-and-cultural-resources,"Fuller, John",chair
@@ -370,7 +385,7 @@ senate-education-and-cultural-resources,"Vinton, Sue",member
 senate-education-and-cultural-resources,"Windy Boy, Jonathan",member
 senate-local-government,"Mandeville, Forrest",chair
 senate-local-government,"Beard, Becky",vice-chair
-senate-local-government,"Dunwell, Mary Ann",vice-chair
+senate-local-government,"Webber, Susan",vice-chair
 senate-local-government,"Bogner, Kenneth",member
 senate-local-government,"Boldman, Ellie",member
 senate-local-government,"Ellsworth, Jason",member
@@ -395,9 +410,9 @@ senate-public-health-welfare-and-safety,"Ricci, Vince",vice-chair
 senate-public-health-welfare-and-safety,"Smith, Laura",vice-chair
 senate-public-health-welfare-and-safety,"Neumann, Cora",member
 senate-public-health-welfare-and-safety,"Emrich, Daniel",member
-senate-public-health-welfare-and-safety,"Flowers, Pat",member
 senate-public-health-welfare-and-safety,"Fuller, John",member
 senate-public-health-welfare-and-safety,"Glimm, Carl",member
+senate-public-health-welfare-and-safety,"Kerr-Carpenter, Emma",member
 senate-public-health-welfare-and-safety,"McGillvray, Tom",member
 senate-public-health-welfare-and-safety,"Windy Boy, Jonathan",member
 senate-public-health-welfare-and-safety,"Yakawich, Mike",member
@@ -414,12 +429,12 @@ senate-agriculture-livestock-and-irrigation,"Gillespie, Bruce ""Butch""",chair
 senate-agriculture-livestock-and-irrigation,"Kassmier, Josh",vice-chair
 senate-agriculture-livestock-and-irrigation,"Boldman, Ellie",vice-chair
 senate-agriculture-livestock-and-irrigation,"Curdy, Willis",member
+senate-agriculture-livestock-and-irrigation,"Dunwell, Mary Ann",member
 senate-agriculture-livestock-and-irrigation,"Glimm, Carl",member
 senate-agriculture-livestock-and-irrigation,"Lenz, Dennis",member
 senate-agriculture-livestock-and-irrigation,"McKamey, Wendy",member
 senate-agriculture-livestock-and-irrigation,"Neumann, Cora",member
 senate-agriculture-livestock-and-irrigation,"Tezek, Tony",member
-senate-agriculture-livestock-and-irrigation,"Webber, Susan",member
 senate-agriculture-livestock-and-irrigation,"Yakawich, Mike",member
 senate-energy-and-telecommunications,"Zolnikov, Daniel",chair
 senate-energy-and-telecommunications,"Lammers, Gayle",vice-chair
@@ -427,7 +442,6 @@ senate-energy-and-telecommunications,"Pope, Christopher",vice-chair
 senate-energy-and-telecommunications,"Bogner, Kenneth",member
 senate-energy-and-telecommunications,"Cuffe, Mike",member
 senate-energy-and-telecommunications,"Ellis, Janet",member
-senate-energy-and-telecommunications,"Flowers, Pat",member
 senate-energy-and-telecommunications,"Galt, Wylie",member
 senate-energy-and-telecommunications,"Harvey, Derek",member
 senate-energy-and-telecommunications,"Hayman, Denise",member

--- a/inputs/lawmakers/committee-assignments-2025.csv
+++ b/inputs/lawmakers/committee-assignments-2025.csv
@@ -290,8 +290,8 @@ joint-appropriations-section-b,"Glimm, Carl",member
 joint-appropriations-section-b,"Kerr-Carpenter, Emma",member
 joint-appropriations-section-b,"Pope, Christopher",member
 joint-appropriations-section-b,"Tempel, Russ",member
-joint-appropriations-section-c,"Schillinger, Jerry",member
-joint-appropriations-section-c,"Cuffe, Mike",member
+joint-appropriations-section-c,"Schillinger, Jerry",chair
+joint-appropriations-section-c,"Cuffe, Mike",vice-chair
 joint-appropriations-section-c,"Albus, Eric",member
 joint-appropriations-section-c,"Bogner, Kenneth",member
 joint-appropriations-section-c,"Ellis, Janet",member

--- a/inputs/lawmakers/committee-assignments-2025.csv
+++ b/inputs/lawmakers/committee-assignments-2025.csv
@@ -353,7 +353,7 @@ senate-business-labor-and-economic-affairs,"Noland, Mark",chair
 senate-business-labor-and-economic-affairs,"Trebas, Jeremy",vice-chair
 senate-business-labor-and-economic-affairs,"Curdy, Willis",vice-chair
 senate-business-labor-and-economic-affairs,"Gillespie, Bruce ""Butch""",member
-senate-business-labor-and-economic-affairs,"Hunter, Greg,member
+senate-business-labor-and-economic-affairs,"Hunter, Greg",member
 senate-business-labor-and-economic-affairs,"Morigeau, Jacinda",member
 senate-business-labor-and-economic-affairs,"Novak, Sara",member
 senate-business-labor-and-economic-affairs,"Loge, Denley",member

--- a/inputs/lawmakers/legislator-roster-2025.json
+++ b/inputs/lawmakers/legislator-roster-2025.json
@@ -839,7 +839,7 @@
         "committees": [
             {
                 "committee": "joint-appropriations-section-c",
-                "role": "member"
+                "role": "vice-chair"
             },
             {
                 "committee": "senate-finance-and-claims",
@@ -1096,8 +1096,8 @@
                 "role": "member"
             },
             {
-                "committee": "senate-local-government",
-                "role": "vice-chair"
+                "committee": "senate-agriculture-livestock-and-irrigation",
+                "role": "member"
             },
             {
                 "committee": "senate-highways-and-transportation",
@@ -1279,6 +1279,14 @@
             }
         ],
         "committees": [
+            {
+                "committee": "joint-appropriations-section-a",
+                "role": "member"
+            },
+            {
+                "committee": "senate-finance-and-claims",
+                "role": "member"
+            },
             {
                 "committee": "senate-local-government",
                 "role": "member"
@@ -1820,19 +1828,19 @@
         ],
         "committees": [
             {
+                "committee": "joint-appropriations-section-a",
+                "role": "member"
+            },
+            {
+                "committee": "senate-finance-and-claims",
+                "role": "member"
+            },
+            {
                 "committee": "senate-taxation",
                 "role": "member"
             },
             {
                 "committee": "senate-natural-resources",
-                "role": "member"
-            },
-            {
-                "committee": "senate-public-health-welfare-and-safety",
-                "role": "member"
-            },
-            {
-                "committee": "senate-energy-and-telecommunications",
                 "role": "member"
             },
             {
@@ -2453,6 +2461,10 @@
         ],
         "committees": [
             {
+                "committee": "senate-taxation",
+                "role": "member"
+            },
+            {
                 "committee": "senate-state-administration",
                 "role": "vice-chair"
             },
@@ -2898,6 +2910,14 @@
         ],
         "committees": [
             {
+                "committee": "joint-appropriations-section-f",
+                "role": "member"
+            },
+            {
+                "committee": "senate-finance-and-claims",
+                "role": "member"
+            },
+            {
                 "committee": "senate-agriculture-livestock-and-irrigation",
                 "role": "vice-chair"
             },
@@ -3022,6 +3042,18 @@
             },
             {
                 "committee": "house-agriculture",
+                "role": "member"
+            },
+            {
+                "committee": "joint-appropriations-section-b",
+                "role": "member"
+            },
+            {
+                "committee": "senate-finance-and-claims",
+                "role": "member"
+            },
+            {
+                "committee": "senate-public-health-welfare-and-safety",
                 "role": "member"
             }
         ],
@@ -3348,6 +3380,10 @@
             }
         ],
         "committees": [
+            {
+                "committee": "senate-business-labor-and-economic-affairs",
+                "role": "member"
+            },
             {
                 "committee": "senate-fish-and-game",
                 "role": "member"
@@ -4763,6 +4799,10 @@
         ],
         "committees": [
             {
+                "committee": "joint-appropriations-section-e",
+                "role": "member"
+            },
+            {
                 "committee": "senate-finance-and-claims",
                 "role": "member"
             },
@@ -5071,7 +5111,7 @@
             },
             {
                 "committee": "joint-appropriations-section-c",
-                "role": "member"
+                "role": "chair"
             }
         ],
         "note": "",
@@ -5591,6 +5631,14 @@
         ],
         "committees": [
             {
+                "committee": "joint-appropriations-section-b",
+                "role": "member"
+            },
+            {
+                "committee": "senate-finance-and-claims",
+                "role": "member"
+            },
+            {
                 "committee": "senate-education-and-cultural-resources",
                 "role": "vice-chair"
             },
@@ -6087,12 +6135,16 @@
         ],
         "committees": [
             {
+                "committee": "senate-business-labor-and-economic-affairs",
+                "role": "member"
+            },
+            {
                 "committee": "senate-education-and-cultural-resources",
                 "role": "member"
             },
             {
-                "committee": "senate-agriculture-livestock-and-irrigation",
-                "role": "member"
+                "committee": "senate-local-government",
+                "role": "vice-chair"
             },
             {
                 "committee": "senate-executive-review-committee",

--- a/process/config/committees.js
+++ b/process/config/committees.js
@@ -1,8 +1,4 @@
 
-// export const COMMITTEE_NAME_CLEANING = {
-// TODO - switch over to model analogous to lawmakers to capture variation in committe names from different places in LAWS
-// }
-
 export const COMMITEE_NAME_CLEANING = {
     // standardizeCommiteeNames in functions.js accounts for '(H) (H)' and '(S) (S)' quirk
     '(H) Appropriations': 'House Appropriations',
@@ -64,14 +60,21 @@ export const COMMITEE_NAME_CLEANING = {
     "(J) (H) Joint Natural Resources": 'Joint Natural Resources',
 }
 
+// Committees that may occur in data that we shouldn't use for pages or list on lawmaker pages
 export const EXCLUDE_COMMITTEES = [
+    
+    // Entire chambers
     'Senate Committee of the Whole',
     'House Committee of the Whole',
+    
+    // Joint committees
     'Joint Education',
     'Joint State Admin',
     'Joint Fish, Wildlife & Parks',
     'Joint Appropriations',
     'Joint Natural Resources',
+    
+    // One-off 2023 committees
     'Select Committee on Judicial Transparency and Accountability',
     'Joint Select Committee on Redistricting',
 ]

--- a/process/main.js
+++ b/process/main.js
@@ -53,8 +53,10 @@ const contactUsComponentText = getText('./inputs/annotations/components/about.md
 */
 
 // config stuff
-const committeeOrder = committeesRaw.map(d => d.name)
+const committeeDisplayOrder = committeesRaw.map(d => d.key)
 
+
+// POPULTE DATA MODELS
 const articles = articlesRaw.map(article => new Article({ article }).export())
 
 /// do lawmakers first, then bills
@@ -65,7 +67,7 @@ const lawmakers = lawmakersRaw.map(lawmaker => new Lawmaker({
     articles: articles.filter(d => d.lawmakerTags.includes(lawmaker.name)),
     // leave sponsoredBills until after bills objects are created
     // same with keyVotes
-    committeeOrder,
+    committeeDisplayOrder,
 }))
 
 const bills = billsRaw.map(bill => new Bill({

--- a/process/main.js
+++ b/process/main.js
@@ -55,8 +55,6 @@ const contactUsComponentText = getText('./inputs/annotations/components/about.md
 // config stuff
 const committeeOrder = committeesRaw.map(d => d.name)
 
-console.log(actionsFlat[35].vote)
-
 const articles = articlesRaw.map(article => new Article({ article }).export())
 
 /// do lawmakers first, then bills

--- a/process/models/Lawmaker.js
+++ b/process/models/Lawmaker.js
@@ -17,34 +17,16 @@ import {
     getLawmakerLastName,
     getLawmakerLocale,
     isLawmakerActive,
+    capitalize,
+    getCommitteeDataByKey,
+    getCommitteeDisplayOrder
 } from '../functions.js'
-
-// Load committees.json and create a mapping of committee titles to their normalized names
-const committeesJson = getJson('inputs/committees/committees.json');
-
-// Create mapping from slug to official name
-const committeeNameMapping = committeesJson.reduce((acc, committee) => {
-    // Create slug from title (e.g. "(H) Judiciary" -> "house-judiciary")
-    const slug = committee.title
-        .toLowerCase()
-        .replace(/^\((h|s)\)\s+/i, (match, chamber) => 
-            chamber.toLowerCase() === 'h' ? 'house-' : 'senate-'
-        )
-        .replace(/\s+/g, '-')
-        .replace(/[^a-z0-9-]/g, '');
-
-    // Map slug to cleaned name from COMMITEE_NAME_CLEANING
-    acc[slug] = COMMITEE_NAME_CLEANING[committee.title] || committee.title;
-    return acc;
-}, {});
-
 export default class Lawmaker {
     constructor({
         lawmaker,
         district,
         annotation,
         articles,
-        committeeOrder,
     }) {
 
         const {
@@ -66,20 +48,6 @@ export default class Lawmaker {
         const standardName = standardizeLawmakerName(name) 
         this.name = standardName
         this.summary = getLawmakerSummary(standardName)
-
-        const committeesCleaned = committees
-            .map(d => {
-                const committeeName = committeeNameMapping[d.committee] || 
-                                   COMMITEE_NAME_CLEANING[d.committee] || 
-                                   d.committee;
-                
-                return {
-                    committee: committeeName,
-                    role: d.role.charAt(0).toUpperCase() + d.role.slice(1)
-                }
-            })
-            .sort((a, b) => committeeOrder.indexOf(a.committee) - committeeOrder.indexOf(b.committee))
-            .filter(d => !EXCLUDE_COMMITTEES.includes(d.committee));
 
         this.data = {
             key: lawmakerKey(standardName),
@@ -103,7 +71,7 @@ export default class Lawmaker {
             party,
             phone,
             email,
-            committees: committeesCleaned,
+            committees: this.mergeCommitteeDataToAssignments(committees, getCommitteeDisplayOrder()),
             leadershipTitle: leadershipRole,
 
             legislativeHistory: sessions.map(({ year, chamber }) => ({ year, chamber })),
@@ -122,7 +90,21 @@ export default class Lawmaker {
         return replacement && replacement.note || null
     }
 
+    mergeCommitteeDataToAssignments = (committeeAssignments, committeeDisplayOrder) => {
+        return committeeAssignments.map(assignment => {
+            const committee = getCommitteeDataByKey(assignment.committee)
+                return {
+                    key: committee.committeeKey,
+                    displayName: committee.displayName,
+                    role: capitalize(assignment.role),
+                }
+            })
+            .sort((a, b) => committeeDisplayOrder.indexOf(a.key) - committeeDisplayOrder.indexOf(b.key))
+            .filter(d => !EXCLUDE_COMMITTEES.includes(d.displayName)) // TODO: Switch this to a key-based system
+    }
+
     addSponsoredBills = ({ sponsoredBills }) => {
+        // not called in constructor because it needs bill data w/ some of the processing done by the Bill model
         this.sponsoredBills = sponsoredBills.map(billData => {
             const {
                 key,
@@ -199,192 +181,3 @@ export default class Lawmaker {
     }
 
 }
-
-
-// Leaving in Just in Case™  
-
-// import { getCsv } from '../utils.js'
-
-// import {
-//     LAWMAKER_REPLACEMENTS,
-// } from '../config/overrides.js'
-
-// import {
-//     // COMMITTEES,
-//     EXCLUDE_COMMITTEES,
-// } from '../config/committees.js'
-
-
-// import {
-//     // filterToFloorVotes,
-//     // lawmakerLastName,
-//     lawmakerKey,
-//     billKey,
-//     standardizeLawmakerName,
-//     getLawmakerSummary,
-//     getLawmakerLastName,
-//     getLawmakerLocale,
-//     standardizeCommiteeNames,
-//     isLawmakerActive,
-// } from '../functions.js'
-
-// export default class Lawmaker {
-//     constructor({
-//         lawmaker,
-//         district,
-//         annotation,
-//         articles,
-//         committeeOrder,
-//     }) {
-
-//         const {
-//             name,
-//             party,
-//             phone,
-//             email,
-//             committees,
-//             image_path,
-//             sessions,
-//             locale,
-//         } = lawmaker
-
-//         const {
-//             // displayName could in theory be used to assign custom lawmaker names from annotation file -- unimplemented though
-//             // Currently this is being handled by the config list acccessed by standardizeLawmakerName
-//             // displayName, 
-//             leadershipRole,
-//             lawmakerPageText
-//         } = annotation
-
-//         const standardName = standardizeLawmakerName(name) 
-//         this.name = standardName
-//         this.summary = getLawmakerSummary(standardName)
-
-//         const committeesCleaned = committees
-//             .map(d => {
-//                 return {
-//                     committee: standardizeCommiteeNames(d.committee),
-//                     role: d.role,
-//                 }
-//             })
-//             .sort((a, b) => committeeOrder.indexOf(a.committee) - committeeOrder.indexOf(b.committee))
-//             .filter(d => !EXCLUDE_COMMITTEES.includes(d.committee))
-
-//         this.data = {
-//             key: lawmakerKey(standardName),
-//             name: standardName,
-//             lastName: getLawmakerLastName(standardName),
-//             locale: getLawmakerLocale(standardName),
-//             isActive: isLawmakerActive(standardName),
-//             district: district.key,
-//             districtElexHistory: {
-//                 last_election: district.last_election,
-//                 pri_elex: district.pri_elex,
-//                 gen_elex: district.gen_elex,
-//                 replacementNote: this.lookForReplacementNote(district.key)
-//             },
-//             districtNum: +district.key.replace('HD ', '').replace('SD ', ''),
-//             districtLocale: district.locale,
-
-//             chamber: district.key[0] === 'S' ? 'senate' : 'house',
-//             title: district.key[0] === 'S' ? 'Sen.' : 'Rep.',
-//             fullTitle: district.key[0] === 'S' ? 'Senator' : 'Representative',
-//             party,
-//             phone,
-//             email,
-//             committees: committeesCleaned,
-//             leadershipTitle: leadershipRole,
-
-//             legislativeHistory: sessions.map(({ year, chamber }) => ({ year, chamber })),
-
-//             articles,
-
-//             lawmakerPageText: lawmakerPageText,
-
-//             imageSlug: image_path.replace('portraits/', '').toLowerCase(),
-
-//         }
-//     }
-
-
-//     lookForReplacementNote = (districtKey) => {
-//         const replacement = LAWMAKER_REPLACEMENTS.find(d => d.district === districtKey)
-//         return replacement && replacement.note || null
-//     }
-
-//     addSponsoredBills = ({ sponsoredBills }) => {
-//         this.sponsoredBills = sponsoredBills.map(bill => {
-//             const {
-//                 key,
-//                 identifier,
-//                 title,
-//                 chamber,
-//                 status,
-//                 progress,
-//                 label,
-//                 textUrl,
-//                 fiscalNoteUrl,
-//                 legalNoteUrl,
-//             } = bill.data
-
-//             return {
-//                 key,
-//                 identifier,
-//                 title,
-//                 chamber,
-//                 status, // object
-//                 progress, // 
-//                 label,
-//                 textUrl,
-//                 fiscalNoteUrl,
-//                 legalNoteUrl,
-//                 numArticles: bill.data.articles.length,
-//                 sponsor: this.summary, // object
-//             }
-//         })
-//     }
-
-//     addKeyBillVotes = ({ name, keyBills }) => {
-//         const keyBillVotes = keyBills
-//             .map(bill => {
-//                 return {
-//                     identifier: bill.data.identifier,
-//                     key: bill.data.key,
-//                     title: bill.data.title,
-//                     explanation: bill.data.explanation,
-//                     lawmakerLastVote: bill.getLastVoteInvolvingLawmaker(name)
-//                 }
-//             })
-//             .filter(bill => bill.lawmakerLastVote !== null)
-//             .map(bill => {
-//                 return {
-//                     identifier: bill.identifier,
-//                     key: bill.key,
-//                     title: bill.title,
-//                     explanation: bill.explanation,
-//                     lawmakerVote: bill.lawmakerLastVote.votes.find(d => d.name === name).option,
-//                     voteData: bill.lawmakerLastVote.data,
-//                 }
-//             })
-//         this.keyBillVotes = keyBillVotes
-
-//     }
-
-//     getVotes = (lawmaker, votes) => {
-//         const lawmakerVotes = votes.filter(vote => {
-//             const voters = vote.votes.map(d => d.name)
-//             return voters.includes(lawmaker.name)
-//         })
-//         return lawmakerVotes
-//     }
-
-//     exportMerged = () => {
-//         return {
-//             ...this.data,
-//             sponsoredBills: this.sponsoredBills || [],
-//             votingSummary: this.votingSummary,
-//             keyBillVotes: this.keyBillVotes || [],
-//         }
-//     }
-
-// }

--- a/src/components/lawmaker/Commitees.js
+++ b/src/components/lawmaker/Commitees.js
@@ -18,14 +18,13 @@ const lawmakerCommitteesStyle = css`
 `;
 
 const LawmakerCommittees = ({ committees }) => {
-  console.log({committees})
   return (
     <div css={lawmakerCommitteesStyle}>
       {committees.map(c => (
-        <div key={c.committee} className="committee">
-          <strong>{c.committee}</strong>
-          {/* <Link href={`/committees/${committeeUrl(c.committee)}`}>
-            <strong>{c.committee}</strong>
+        <div key={c.key} className="committee">
+          <strong>{c.displayName}</strong>
+          {/* <Link href={`/committees/${committeeUrl(c.key)}`}>
+            <strong>{c.displayName}</strong>
           </Link> */}
           {c.role !== 'Member' ? ` - ${c.role} ${c.role === 'Chair' ? '🪑' : ''}` : null}
         </div>


### PR DESCRIPTION
Note that I didn't commit updates to the data files here to avoid merge issues — I did run process locally for a check though.

A couple other things:
- Note that I added committee data lookup functions to `process/function.js`, which is intended to be a central place to stash utility-ish functions that could be used by multiple models in the processing system (e.g. when we get to matching bill actions to committees, we'll be in theory able to use the same set of utility functions to pull committee data from `inputs/committees/commitees/csv`). There's also stuff in there like a `capitalize()` function so we can write that once and use it across the processing framework.
- I also cleaned up some code you had that was doing similar processing inside the Lawmaker model.
- The `committeeKey` field in that committees CSV is intended to be a key that can serve as a unique identifier for a committee as well as the URL slug once we get back to committee pages
- For each lawmaker's committee assignments array, we're now feeding the frontend both a key field (for use in setting up links) and a displayName field that's intended for human consumption
- There's still some work to be done on the workflow that takes whatever version of a committee name the official legislative system is using and maps it to a standardize key we can use to look up the committee data we're specifying by hand (meeting day/time, etc.)
- I updated the committee assignment CSV, `inputs/lawmakers/committee-assignments-2025.py` to match the updated Senate assignments... hopefully.