### PR TITLE
Fix progression

### DIFF
--- a/process/config/committees.js
+++ b/process/config/committees.js
@@ -20,9 +20,11 @@ export const COMMITEE_NAME_CLEANING = {
 
     '(S) Finance and Claims': 'Senate Finance and Claims',
     '(S) Judiciary': 'Senate Judiciary',
-    '(S) Business, Labor, and Economic Affairs': 'Senate Business, Labor, and Economic Affairs',
+    '(S) Business, Labor, and Economic Affairs': 'Senate Business, Labor and Economic Affairs',
+    '(S) Business, Labor and Economic Affairs': 'Senate Business, Labor and Economic Affairs',
     '(S) Taxation': 'Senate Taxation',
-    '(S) Energy and Telecommunications': 'Senate Energy and Telecommunications',
+    '(S) Energy and Telecommunications': 'Senate Energy, Technology and Federal Relations',
+    '(S) Energy, Technology & Federal Relations': 'Senate Energy, Technology and Federal Relations',
     '(S) Local Government': 'Senate Local Government',
     '(S) Natural Resources': 'Senate Natural Resources',
     '(S) Public Health, Welfare and Safety': 'Senate Public Health, Welfare and Safety',

--- a/process/config/procedure.js
+++ b/process/config/procedure.js
@@ -128,8 +128,10 @@ const isMajor = true
 const isHighlight = true
 
 // Bill progression flags
+const inDrafting = true
 const draftRequest = true
 const draftReady = true
+const draftToSponsor = true
 const introduction = true
 
 const hearing = true
@@ -172,6 +174,8 @@ const ultimatelyPassed = true
 
 const committeeReferral = true
 const committeeSubsequentReferral = true
+
+const secretaryOfStateAction = true
 
 
 export const ACTIONS = [
@@ -364,7 +368,7 @@ export const ACTIONS = [
     // Ultimate outcomes
     { key: 'Died in Standing Committee', isMajor, ultimatelyFailed },
     { key: 'Died in Process', isMajor, firstChamberFloorAction, ultimatelyFailed }, // resolutions?
-    { key: 'Chapter Number Assigned', isMajor, ultimatelyPassed },
+    { key: 'Chapter Number Assigned', isMajor, ultimatelyPassed, secretaryOfStateAction },
     { key: 'Filed with Secretary of State', isMajor, ultimatelyPassed },
 
     // conference committees
@@ -376,28 +380,30 @@ export const ACTIONS = [
 
 
     // Minor actions (exclude from default bill table view)
-    { key: 'Drafter Assigned' },
-    { key: 'Draft Request Received', draftRequest },
-    { key: 'Bill Draft Text Available Electronically', draftReady },
-    { key: 'Draft Delivered to Requester' },
-    { key: 'Draft Back for Redo', },
-    { key: 'Draft Back for Requester Changes', },
-    { key: 'Draft On Hold', },
-    { key: 'Draft Ready for Delivery', },
-    { key: 'Draft Taken Off Hold', },
-    { key: 'Draft Taken by Drafter', },
-    { key: 'Draft in Assembly', },
-    { key: 'Draft in Edit', },
-    { key: 'Draft in Final Drafter Review', },
-    { key: 'Draft in Input/Proofing', },
-    { key: 'Draft in Legal Review', },
-    { key: 'Draft to Drafter - Edit Review', },
-    { key: 'Draft to Drafter - Edit Review [CMD]', },
-    { key: 'Draft to Drafter - Edit Review [KWK]', },
-    { key: 'Draft to Drafter - Edit Review [SMH]', },
-    { key: 'Draft to Requester for Review', },
-    { key: 'Executive Director Final Review', },
-    { key: 'Executive Director Review', },
+    { key: 'Drafter Assigned', inDrafting },
+    { key: 'Draft Request Received', inDrafting, draftRequest },
+    { key: 'Bill Draft Text Available Electronically', inDrafting, draftReady },
+    { key: 'Draft Back for Redo', inDrafting},
+    { key: 'Draft Back for Requester Changes', inDrafting},
+    { key: 'Draft On Hold', inDrafting},
+    { key: 'Draft Ready for Delivery', inDrafting},
+    { key: 'Draft Taken Off Hold', inDrafting},
+    { key: 'Draft Taken by Drafter', inDrafting},
+    { key: 'Draft in Assembly', inDrafting},
+    { key: 'Draft in Edit', inDrafting},
+    { key: 'Draft in Final Drafter Review', inDrafting},
+    { key: 'Draft in Input/Proofing', inDrafting},
+    { key: 'Draft in Legal Review', inDrafting},
+    { key: 'Draft to Drafter - Edit Review', inDrafting},
+    { key: 'Draft to Drafter - Edit Review [CMD]', inDrafting},
+    { key: 'Draft to Drafter - Edit Review [KWK]', inDrafting},
+    { key: 'Draft to Drafter - Edit Review [SMH]', inDrafting},
+    { key: 'Draft to Requester for Review', inDrafting},
+    { key: 'Executive Director Final Review', inDrafting},
+    { key: 'Executive Director Review', inDrafting},
+
+    { key: 'Draft Delivered to Requester', draftToSponsor},
+
     { key: 'Fiscal Note Printed', },
     { key: 'Fiscal Note Probable', },
     { key: 'Fiscal Note Received', },

--- a/process/functions.js
+++ b/process/functions.js
@@ -38,6 +38,7 @@ export const standardizeDate = date => {
 
 export const standardCommiteeNames = Array.from(new Set(Object.values(COMMITEE_NAME_CLEANING)))
 export const standardizeCommiteeNames = name => {
+    if (name === "undefined") return null
     if (standardCommiteeNames.includes(name)) return name
     if ([null, '', ' ', '  ', '   ', '    '].includes(name)) return null
     const preClean = name.replace('(H) (H)', '(H)').replace('(S) (S)', '(S)')

--- a/process/functions.js
+++ b/process/functions.js
@@ -42,6 +42,7 @@ export const standardizeCommiteeNames = name => {
     if (standardCommiteeNames.includes(name)) return name
     if ([null, '', ' ', '  ', '   ', '    '].includes(name)) return null
     const preClean = name.replace('(H) (H)', '(H)').replace('(S) (S)', '(S)')
+        .replace('  ',' ')
     if (preClean.includes('Free Conference Committee')) return 'Free Conference Committee'
     if (preClean.includes('Conference Committee')) return 'Conference Committee'
     const clean = COMMITEE_NAME_CLEANING[preClean]

--- a/process/main.js
+++ b/process/main.js
@@ -63,7 +63,7 @@ const lawmakers = lawmakersRaw.map(lawmaker => new Lawmaker({
     // same with keyVotes
 }))
 
-const bills = billsRaw.filter(d => d.key === 'HB 1').map(bill => new Bill({
+const bills = billsRaw.map(bill => new Bill({
     bill,
     actions: actionsFlat.filter(d => d.bill === bill.key),
     votes: actionsFlat.filter(d => d.vote && d.vote.bill === bill.key).map(d => d.vote),

--- a/process/main.js
+++ b/process/main.js
@@ -51,9 +51,6 @@ const contactUsComponentText = getText('./inputs/annotations/components/about.md
 ### DATA BUNDLING + WRANGLING
 */
 
-// config stuff
-const committeeOrder = committeesRaw.map(d => d.name)
-
 const articles = articlesRaw.map(article => new Article({ article }).export())
 
 /// do lawmakers first, then bills
@@ -64,7 +61,6 @@ const lawmakers = lawmakersRaw.map(lawmaker => new Lawmaker({
     articles: articles.filter(d => d.lawmakerTags.includes(lawmaker.name)),
     // leave sponsoredBills until after bills objects are created
     // same with keyVotes
-    committeeOrder,
 }))
 
 const bills = billsRaw.filter(d => d.key === 'HB 1').map(bill => new Bill({
@@ -83,19 +79,19 @@ const senateFloorVotes = votes.filter(v => v.voteLocation === 'floor' && v.voteC
 const houseFloorVoteAnalysis = new VotingAnalysis({ votes: houseFloorVotes })
 const senateFloorVoteAnalysis = new VotingAnalysis({ votes: senateFloorVotes })
 
-const committees = committeesRaw
-    .filter(d => ![
-        'conference',
-        'select',
-        'procedural',
-        // 'fiscal-sub'
-    ].includes(d.type))
-    .map(schema => new Committee({
-        schema,
-        committeeBills: bills.filter(b => b.committees.includes(schema.displayName)),
-        lawmakers: lawmakers.filter(l => l.data.committees.map(d => d.committee).includes(schema.name)), // Cleaner to do this backwards -- assign lawmakers based on committee data?
-        updateTime
-    }))
+// const committees = committeesRaw
+//     .filter(d => ![
+//         'conference',
+//         'select',
+//         'procedural',
+//         // 'fiscal-sub'
+//     ].includes(d.type))
+//     .map(schema => new Committee({
+//         schema,
+//         committeeBills: bills.filter(b => b.committees.includes(schema.displayName)),
+//         lawmakers: lawmakers.filter(l => l.data.committees.map(d => d.committee).includes(schema.name)), // Cleaner to do this backwards -- assign lawmakers based on committee data?
+//         updateTime
+//     }))
 
 // Calculations that need both lawmakers and bills populated
 lawmakers.forEach(lawmaker => {
@@ -159,24 +155,6 @@ const contactComponentOutput = {
 ### OUTPUTS 
 */
 console.log('\n### Bundling tracker data')
-/*
-Exporting bill actions separately here so they can be kept outside of Gatsby graphql scope
-*/
-
-// Group actions by bill
-// const groupedActions = actionsFlat.reduce((acc, action) => {
-//     if (!acc[action.bill]) {
-//         acc[action.bill] = [];
-//     }
-//     acc[action.bill].push(action);
-//     return acc;
-// }, {});
-
-// // Convert grouped actions to the desired format
-// const actionsOutput = Object.keys(groupedActions).map(bill => ({
-//     bill,
-//     actions: groupedActions[bill]
-// }));
 
 const billsOutput = bills.map(b => b.exportBillDataOnly())
 const actionsOutput = bills.map(b => ({
@@ -196,8 +174,8 @@ writeJson('./src/data/bills.json', billsOutput)
 
 const lawmakerOutput = lawmakers.map(l => l.exportMerged())
 writeJson('./src/data/lawmakers.json', lawmakerOutput)
-const committeeOutput = committees.map(l => l.export())
-writeJson('./src/data/committees.json', committeeOutput)
+// const committeeOutput = committees.map(l => l.export())
+// writeJson('./src/data/committees.json', committeeOutput)
 
 writeJson('./src/data/header.json', headerOutput)
 writeJson('./src/data/articles.json', articles)

--- a/process/main.js
+++ b/process/main.js
@@ -67,7 +67,7 @@ const lawmakers = lawmakersRaw.map(lawmaker => new Lawmaker({
     committeeOrder,
 }))
 
-const bills = billsRaw.map(bill => new Bill({
+const bills = billsRaw.filter(d => d.key === 'HB 1').map(bill => new Bill({
     bill,
     actions: actionsFlat.filter(d => d.bill === bill.key),
     votes: actionsFlat.filter(d => d.vote && d.vote.bill === bill.key).map(d => d.vote),
@@ -114,9 +114,9 @@ lawmakers.forEach(lawmaker => {
     }
 })
 
-const calendarOutput = new CalendarPage({ actions: actionsFlat, bills, updateTime }).export()
-bills.forEach(bill => bill.data.isOnCalendar = calendarOutput.billsOnCalendar.includes(bill.data.identifier))
-const recapOutput = new RecapPage({ actions: actionsFlat, bills, updateTime }).export()
+// const calendarOutput = new CalendarPage({ actions: actionsFlat, bills, updateTime }).export()
+// bills.forEach(bill => bill.data.isOnCalendar = calendarOutput.billsOnCalendar.includes(bill.data.identifier))
+// const recapOutput = new RecapPage({ actions: actionsFlat, bills, updateTime }).export()
 
 const keyBillCategoryKeys = Array.from(new Set(billAnnotations.map(d => d.category))).filter(d => d !== null).filter(d => d !== undefined)
 const keyBillCategoryList = keyBillCategoryKeys.map(category => {
@@ -192,7 +192,6 @@ for (let start = 0; start < actionsOutput.length; start += chunkSize) {
     index += 1
 }
 
-// const billsOutput = bills.map(b => b.exportBillDataOnly())
 writeJson('./src/data/bills.json', billsOutput)
 
 const lawmakerOutput = lawmakers.map(l => l.exportMerged())
@@ -204,9 +203,9 @@ writeJson('./src/data/header.json', headerOutput)
 writeJson('./src/data/articles.json', articles)
 writeJson('./src/data/process-annotations.json', processNotes)
 writeJson('./src/data/bill-categories.json', keyBillCategoryList)
-writeJson('./src/data/calendar.json', calendarOutput)
-writeJson('./src/data/recap.json', recapOutput)
-writeJson('./src/data/participation.json', participationPageOutput)
+// writeJson('./src/data/calendar.json', calendarOutput)
+// writeJson('./src/data/recap.json', recapOutput)
+// writeJson('./src/data/participation.json', participationPageOutput)
 writeJson('./src/data/contact.json', contactComponentOutput)
 writeJson('./src/data/house.json', housePageOutput)
 writeJson('./src/data/senate.json', senatePageOutput)


### PR DESCRIPTION
This fixes the (most of the) bugs we've been seeing with how actions are being mapped to bill progression. There's still a quirk on the reconciliation step on HB 1 that's attributable to a weird combination of bill actions.

I've also done a little bit of cleanup and documenting here and there, though the Bill `getProgress` logic is still a nightmare. In the mid-term, we should look at how the official site pizza tracker is set up and see if we can replace that logic to avoid what will be constant maintenance headaches.