### PR TITLE
updated lawmaker roster/annoations

### DIFF
--- a/inputs/lawmakers/legislator-roster-2025.json
+++ b/inputs/lawmakers/legislator-roster-2025.json
@@ -2716,7 +2716,7 @@
         "last_name": "Isaly",
         "district": "HD 58",
         "party": "D",
-        "locale": "Bozeman",
+        "locale": "Livingston",
         "phone": "406-209-2568",
         "email": "Jamie.Isaly@legmt.gov",
         "sessions": [

--- a/inputs/lawmakers/legislator-roster-2025.json
+++ b/inputs/lawmakers/legislator-roster-2025.json
@@ -4699,10 +4699,6 @@
         "email": "Debo.Powers@legmt.gov",
         "sessions": [
             {
-                "year": "2019",
-                "chamber": "house"
-            },
-            {
                 "year": "2025",
                 "chamber": "house"
             }

--- a/inputs/lawmakers/legislator-session-history.json
+++ b/inputs/lawmakers/legislator-session-history.json
@@ -1979,10 +1979,6 @@
         "name": "Debo Powers",
         "sessions": [
             {
-                "year": "2019",
-                "chamber": "house"
-            },
-            {
                 "year": "2025",
                 "chamber": "house"
             }

--- a/inputs/lawmakers/roster-annotations.csv
+++ b/inputs/lawmakers/roster-annotations.csv
@@ -1,2 +1,4 @@
 roster_name,custom_key,custom_name,custom_locale
 Barry Usher,,,Laurel
+Jamie Isaly,,,Livingston
+Mark Thane,,,Missoula


### PR DESCRIPTION
**In this PR**:
1) Updates to `Mark Thane`, `Jamie Isaly` and `Debo Powers`
2) Mark and Jamie Locale changed via `annotations.csv`
3) Debo changed directly (removed 2019 from `sessions`)