### PR TITLE
House/Senate page photos

### DIFF
--- a/src/components/LawmakerTable.js
+++ b/src/components/LawmakerTable.js
@@ -126,8 +126,9 @@ const Row = ({ name, party, district, locale, portrait, lawmakers }) => {
             <td>
                 {imageUrl && (
                     <a href={imageUrl} target="_blank" rel="noopener noreferrer">
-                        {/* TODO: Adjust sizing on the photo */}
-                        <img src={imageUrl} alt={`Portrait of ${name}`} css={{ width: '80px', height: 'auto' }} />
+                        <div css={{ width: '80px', height: '80px', overflow: 'hidden', position: 'relative' }}>
+                            <img src={imageUrl} alt={`Portrait of ${name}`} css={{ width: '100%', height: 'auto', position: 'absolute', top: '0' }} />
+                        </div>
                     </a>
                 )}
             </td>


### PR DESCRIPTION
**In this PR**
1) Adjust CSS in LawmakerTable to crop bottom of image off  so it is a square rather than a rectangle. 

*before:*
<img width="822" alt="Screenshot 2025-02-09 at 12 55 14 PM" src="https://github.com/user-attachments/assets/31f8c31a-31cd-4229-a7b6-8117c5097a6c" />

*after:*
<img width="812" alt="Screenshot 2025-02-09 at 12 55 06 PM" src="https://github.com/user-attachments/assets/c9c24238-3d93-4608-a896-ad2a2b968128" />
