### PR TITLE
Styling for `hide vote breakdown`

### DIFF
--- a/src/components/bill/Actions.js
+++ b/src/components/bill/Actions.js
@@ -359,7 +359,7 @@ const VoteListing = ({ votes, voteUrl, defaultOpen = false }) => {
     }
     {
       isOpen ?
-        <button className='inlineButton' onClick={() => setIsOpen(false)}>
+        <button className='inline-button' onClick={() => setIsOpen(false)}>
           Hide full vote breakdown
         </button> : null
     }


### PR DESCRIPTION
**In this PR**
1) Deal with a small single line change to fix styling for the bottom `Hide full vote breakdown` button on the bill pages. 