### PR TITLE
Cora Neumann Helena -> Bozeman

### DIFF
--- a/inputs/lawmakers/legislator-roster-2025.json
+++ b/inputs/lawmakers/legislator-roster-2025.json
@@ -4194,7 +4194,7 @@
         "last_name": "Neumann",
         "district": "SD 30",
         "party": "D",
-        "locale": "Helena",
+        "locale": "Bozeman",
         "phone": "406-210-7969",
         "email": "Cora.Neumann@legmt.gov",
         "sessions": [

--- a/inputs/lawmakers/roster-annotations.csv
+++ b/inputs/lawmakers/roster-annotations.csv
@@ -2,3 +2,4 @@ roster_name,custom_key,custom_name,custom_locale
 Barry Usher,,,Laurel
 Jamie Isaly,,,Livingston
 Mark Thane,,,Missoula
+Cora Neumann,,,Bozeman


### PR DESCRIPTION
**In this PR**
1) Updated annotations to deal with the fact that official address is listed as the Capitol and thus `Helena`. Now says bozeman. 
2) Ran the `make-lawmaker-roster-2025.py` script to ensure it is picked up when the data pipeline runs