### PR TITLE
Changes to GHA and adding a nightly refresh all pdfs

### DIFF
--- a/.github/workflows/data.yml
+++ b/.github/workflows/data.yml
@@ -5,7 +5,13 @@ on:
     branches:
       - main
   schedule:
-    - cron: '*/20 * * * *'
+    # Mountain Standard Time (GMT-7): Runs 5am to 12am MST (Switch to this when DST ends in November)
+    # Runs every 20 minutes from 12pm (noon) UTC to 11pm and then Midnight UTC to 6:59am. Working out to 5am to 11:59pm MST
+    # Note: Both are written to deal with the fact that we are jumping dates in the middle of the night.
+    - cron: '*/20 12-23,0-6 * * *'
+    #  Runs every 20 minutes from 11am UTC to 11pm and then Midnight UTC to 5:59am. Working out to 5am to 11:59pm MDT
+    # Mountain Daylight Time (GMT-6): Runs 5am to 12am MDT (Switch to this when DST starts in March)
+    # - cron: '*/20 11-23,0-5 * * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/refresh-all-pdfs.yml
+++ b/.github/workflows/refresh-all-pdfs.yml
@@ -1,0 +1,66 @@
+name: Refresh all PDFs nightly
+
+on:
+    schedule:
+    # Change these out when DST happens in March and November
+      # Run once per day at 8am UTC (1am Mountain Standard Time GMT-7)
+      - cron: '0 8 * * *'
+      # Run once per day at 7am UTC (1am Mountain Daylight Time GMT-6)
+    #   - cron: '0 7 * * *'
+    workflow_dispatch:
+
+jobs:
+  full-download:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      
+    # Restore dependencies if needed 
+    - name: Restore Node.js dependencies cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-npm-cache-${{ hashFiles('package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-npm-cache-
+
+    # Set up Node.js
+    - name: Set up Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '23'
+        cache: 'npm'
+
+    # Install dependencies
+    - name: Install dependencies
+      run: npm install
+
+    # Ensure the nightly-pdf-refresh.sh script is executable
+    - name: Make nightly-pdf-refresh.sh executable
+      run: chmod +x ./nightly-pdf-refresh.sh
+
+    # Run the nightly-pdf-refresh.sh script
+    - name: Run the nightly-pdf-refresh.sh script
+      run: ./nightly-pdf-refresh.sh
+
+    # Save Node.js dependencies cache
+    - name: Save Node.js dependencies cache
+      if: always()
+      uses: actions/cache@v4
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-npm-cache-${{ hashFiles('package-lock.json') }}
+
+    # Commit and push if changed
+    - name: Commit and push if changed
+      run: |-
+        git config user.name "Automated"
+        git config user.email "actions@users.noreply.github.com"
+        git add -A
+        timestamp=$(date -u)
+        git commit -m "Latest data: ${timestamp}" || exit 0
+        git push

--- a/inputs/nightly-full-refresh/fetch-all-bill-notes.js
+++ b/inputs/nightly-full-refresh/fetch-all-bill-notes.js
@@ -1,0 +1,116 @@
+import fetch from 'node-fetch';
+import fs from 'fs/promises';
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+const GITHUB_API_URLS = {
+    legalNotes: 'https://api.github.com/repos/mtfreepress/legislative-interface/contents/interface/downloads/legal-note-pdfs-2',
+    fiscalNotes: 'https://api.github.com/repos/mtfreepress/legislative-interface/contents/interface/downloads/fiscal-note-pdfs-2'
+};
+
+const RAW_URL_BASES = {
+    legalNotes: 'https://raw.githubusercontent.com/mtfreepress/legislative-interface/main/interface/downloads/legal-note-pdfs-2/',
+    fiscalNotes: 'https://raw.githubusercontent.com/mtfreepress/legislative-interface/main/interface/downloads/fiscal-note-pdfs-2/'
+};
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const OUT_DIRS = {
+    legalNotes: path.join(__dirname, '../../public/legal-notes'),
+    fiscalNotes: path.join(__dirname, '../../public/fiscal-notes')
+};
+
+const fetchJson = async (url) => {
+    const headers = process.env.GITHUB_TOKEN ? {
+        'Authorization': `token ${process.env.GITHUB_TOKEN}`,
+        'Accept': 'application/vnd.github.v3+json'
+    } : {};
+
+    const response = await fetch(url, { headers });
+    if (!response.ok) {
+        throw new Error(`Failed to fetch JSON from ${url}, status: ${response.status}`);
+    }
+    return await response.json();
+};
+
+const createFolderIfNotExists = async folderPath => {
+    try {
+        await fs.mkdir(folderPath, { recursive: true });
+        console.log(`Created folder: ${folderPath}`);
+    } catch (error) {
+        if (error.code !== 'EEXIST') {
+            throw error;
+        }
+    }
+};
+
+const clearDirectory = async (dirPath) => {
+    try {
+        const files = await fs.readdir(dirPath);
+        for (const file of files) {
+            await fs.unlink(path.join(dirPath, file));
+            console.log(`Deleted old file: ${file}`);
+        }
+    } catch (error) {
+        if (error.code !== 'ENOENT') {
+            throw error;
+        }
+    }
+};
+
+const downloadFile = async (url, fileName, folderPath) => {
+    console.log(`Fetching ${url}`);
+    const response = await fetch(url);
+    if (!response.ok) {
+        throw new Error(`Failed to fetch URL: ${url}, status: ${response.status}`);
+    }
+    
+    // Clear any existing files before downloading new one
+    await clearDirectory(folderPath);
+    
+    const data = await response.buffer();
+    const outputPath = path.join(folderPath, fileName);
+    await fs.writeFile(outputPath, data);
+    console.log(`Saved ${fileName} to ${outputPath}`);
+};
+
+const fetchAllFiles = async (type) => {
+    console.log(`Fetching all ${type}...`);
+    
+    // Get the list of all directories (bill folders)
+    const directories = await fetchJson(GITHUB_API_URLS[type]);
+    
+    for (const dir of directories) {
+        if (dir.type !== 'dir') continue;
+        
+        // Get contents of each bill directory
+        const billContents = await fetchJson(dir.url);
+        const pdfFiles = billContents.filter(file => file.name.endsWith('.pdf'));
+        
+        if (pdfFiles.length === 0) continue;
+        
+        // Create local folder for this bill
+        const folderPath = path.join(OUT_DIRS[type], dir.name);
+        await createFolderIfNotExists(folderPath);
+        
+        // Download all PDFs for this bill
+        for (const pdf of pdfFiles) {
+            const fileUrl = `${RAW_URL_BASES[type]}${dir.name}/${pdf.name}`;
+            await downloadFile(fileUrl, pdf.name, folderPath);
+        }
+    }
+};
+
+const main = async () => {
+    try {
+        console.log('Starting full download of all bill notes...');
+        await fetchAllFiles('legalNotes');
+        await fetchAllFiles('fiscalNotes');
+        console.log('Successfully downloaded all bill notes!');
+    } catch (error) {
+        console.error(`Error downloading all bill notes: ${error.message}`);
+        process.exit(1);
+    }
+};
+
+main();

--- a/nightly-pdf-refresh.sh
+++ b/nightly-pdf-refresh.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+measure_time() {
+    local start_time=$(date +%s)
+    echo "Running: $@"
+    "$@"
+    local end_time=$(date +%s)
+    local elapsed_time=$((end_time - start_time))
+    echo "Time taken: ${elapsed_time} seconds"
+}
+
+# Print start time
+echo "Starting nightly PDF refresh at $(date)"
+
+# Make sure we are in project root directory
+cd "$(dirname "$0")"
+
+# Run the bill notes fetcher
+echo "Fetching all bill notes..."
+measure_time node inputs/nightly-full-refresh/fetch-all-bill-notes.js
+
+# TODO: Fetch all bill text PDFs goes here:
+
+# Print completion time
+echo "Completed nightly PDF refresh at $(date)"


### PR DESCRIPTION
### **In this PR**:
1. Add a `refresh-all-pdfs.yml` GHA script
   a. Invokes a `nighly-pdf-refresh.sh` script
   b. `nighly-pdf-refresh.sh` triggers a `fetch-all-bill-notes.js` file to grab all PDFs (rather than just grabbing those in the 
        list we pass from the interface of ones that were updated on the most recent pass)
2. Change main refresh and redeploy to only happen from 5am to 11:59pm to give us some downtime to run a full refresh of all documents to ensure consistency
3. Changes support our changes to the `fetch-bill-notes.js` to ensure file consistency and no duplicates. 

### **Todo**: 

1. Add a script to grab all PDF bill text
2. Add an incremental script like we have for `fetch-bill-notes.js`

