### PR TITLE
Reduce Verbosity to make GHA logs usable

### DIFF
--- a/inputs/bills/fetch-bill-notes.js
+++ b/inputs/bills/fetch-bill-notes.js
@@ -76,7 +76,7 @@ const downloadFile = async (url, fileName, folderPath) => {
     const data = await response.buffer();
     const outputPath = path.join(folderPath, fileName);
     await fs.writeFile(outputPath, data);
-    console.log(`Saved ${fileName} to ${outputPath}`);
+    // console.log(`Saved ${fileName} to ${outputPath}`);
 };
 
 const processUpdates = async (type) => {

--- a/inputs/bills/fetch.js
+++ b/inputs/bills/fetch.js
@@ -45,7 +45,7 @@ const downloadFile = async (url, fileName, folderPath) => {
     const data = await fetchJson(url);
     const outputPath = path.join(folderPath, fileName);
     await writeJson(outputPath, data);
-    console.log(`Saved ${fileName} to ${outputPath}`);
+    // console.log(`Saved ${fileName} to ${outputPath}`);
 };
 
 const main = async () => {

--- a/process/utils.js
+++ b/process/utils.js
@@ -31,7 +31,8 @@ export const getCsv = async (path) => {
 export const writeJson = (path, data) => {
     fs.writeFile(path, JSON.stringify(data, null, 4), function (err) {
         if (err) throw err;
-        console.log('    JSON written to', path);
+    // Too verbose for prod. Ends up spitting out thousands of lines in GHA
+        // console.log('    JSON written to', path);
     });
 }
 
@@ -47,6 +48,6 @@ export const writeCsv = (path, array) => {
     })
     fs.writeFile(path, output.join('\n'), function (err) {
         if (err) throw err;
-        console.log('    CSV written to', path);
+        // console.log('    CSV written to', path);
     });
 }


### PR DESCRIPTION
### **In this PR**:
1) Comment out logging from writeJson and writeCsv to make logs on GHA manageable. Spitting out nearly 7000 lines of `writing JSON` logs. 
2) Comment out logging for download file, comprising the rest of our unmanageable GHA logs.
3) Error handling left in place 