### PR TITLE
Nightly refresh changes

### DIFF
--- a/nightly-pdf-refresh.sh
+++ b/nightly-pdf-refresh.sh
@@ -8,17 +8,44 @@ measure_time() {
     echo "Time taken: ${elapsed_time} seconds"
 }
 
+# --------------------------------------------
+# Prep work:
+
 # Print start time
 echo "Starting nightly PDF refresh at $(date)"
 
 # Make sure we are in project root directory
 cd "$(dirname "$0")"
 
+# --------------------------------------------
+# Data pipeline: 
+
+# Check MTFP website CMS for stories associated with particular bills/lawmakers
+measure_time node inputs/coverage/fetch.js
+
+# Check laws-interface repo for bill/vote info pulled from official legislative system
+echo "Fetching all data, this may take awhile..."
+measure_time node inputs/bills/fetch.js
+
 # Run the bill notes fetcher
 echo "Fetching all bill notes..."
 measure_time node inputs/nightly-full-refresh/fetch-all-bill-notes.js
 
 # TODO: Fetch all bill text PDFs goes here:
+
+# --------------------------------------------
+# Build & Deploy:
+
+echo "Building next app"
+# Build
+measure_time npx next build
+echo "Deploying to AWS S3"
+# Deploy
+measure_time aws s3 sync build s3://projects.montanafreepress.org/capitol-tracker-2025 --delete
+measure_time aws cloudfront create-invalidation --distribution-id E1G7ISX2SZFY34 --paths "/capitol-tracker-2025/*"
+
+# --------------------------------------------
+# Closing time:
 
 # Print completion time
 echo "Completed nightly PDF refresh at $(date)"


### PR DESCRIPTION
### **In this PR:**
1) `nightly-pdf-refresh.sh` now 
    a) grabs all bill data, articles etc. 
    b) deploys to AWS
2) Along with the previous full PDF refresh to ensure data integrity
3) Uses `measure_time` to display how long each step takes. 

#### **Todo:**
1) Figure out what bills/fetch.js is throwing an error about ES modules while other seemingly identical scripts to fetch other things aren't. Not breaking anything so low priority. 
