### PR TITLE
Committee names displaying as expected 

### DIFF
--- a/src/components/bill/Actions.js
+++ b/src/components/bill/Actions.js
@@ -140,12 +140,12 @@ const Action = (action, showVotes, annotations) => {
 
   const displayDate = committeeHearingTime ? committeeHearingTime : date;
   
-  // Format committee name for display
+  // format committee name for display
   let committeeDisplay = null;
   if (committee && description === "Hearing") {
-    // Extract the chamber and clean up the committee name
+    // extract the chamber and clean up the committee name
     const chamberPrefix = committee.includes("(H)") ? "House" : committee.includes("(S)") ? "Senate" : "";
-    // Remove the parenthetical prefix from the committee name
+    // remove the parenthetical prefix from the committee name
     const cleanCommitteeName = committee.replace(/\([HS]\)\s*/, "").trim();
     committeeDisplay = `${chamberPrefix} ${cleanCommitteeName}`;
   }

--- a/src/components/bill/Actions.js
+++ b/src/components/bill/Actions.js
@@ -139,10 +139,10 @@ const Action = (action, showVotes, annotations) => {
   const { thresholdRequired } = vote || {};
 
   const displayDate = committeeHearingTime ? committeeHearingTime : date;
-  
+
   // format committee name for display
   let committeeDisplay = null;
-  if (committee && description === "Hearing") {
+  if (committee && (description === "Hearing" || description.startsWith("Committee Executive Action"))) {
     // extract the chamber and clean up the committee name
     const chamberPrefix = committee.includes("(H)") ? "House" : committee.includes("(S)") ? "Senate" : "";
     // remove the parenthetical prefix from the committee name

--- a/src/components/bill/Actions.js
+++ b/src/components/bill/Actions.js
@@ -74,6 +74,7 @@ const highlightRow = css`
 `;
 
 const BillActions = ({ actions, lawsUrl, vetoMemoUrl }) => {
+  console.log(actions)
   const [showMinorActions, setShowMinorActions] = useState(false);
   const [showVotes, setShowVotes] = useState(true);
 
@@ -139,6 +140,16 @@ const Action = (action, showVotes, annotations) => {
   const { thresholdRequired } = vote || {};
 
   const displayDate = committeeHearingTime ? committeeHearingTime : date;
+  
+  // Format committee name for display
+  let committeeDisplay = null;
+  if (committee && description === "Hearing") {
+    // Extract the chamber and clean up the committee name
+    const chamberPrefix = committee.includes("(H)") ? "House" : committee.includes("(S)") ? "Senate" : "";
+    // Remove the parenthetical prefix from the committee name
+    const cleanCommitteeName = committee.replace(/\([HS]\)\s*/, "").trim();
+    committeeDisplay = `${chamberPrefix} ${cleanCommitteeName}`;
+  }
 
   return (
     <tr key={id} css={isHighlight ? highlightRow : null}>
@@ -150,16 +161,11 @@ const Action = (action, showVotes, annotations) => {
         <div css={actionWidth}>
           <div css={descriptionCss}>
             <div>{description}</div>
-            <div>
-              {committee && (
-                <>
-                  {/* TODO: This is broken restore when we fix committees */}
-                  {/* 👥 <em>
-                    <Link href={`/committees/${committeeUrl(committee)}`}>{committee}</Link>
-                  </em> */}
-                </>
-              )}
-            </div>
+            {committeeDisplay && (
+              <div>
+                👥 <em>{committeeDisplay}</em>
+              </div>
+            )}
           </div>
 
           {vote && thresholdRequired !== 'simple' ? (
@@ -200,7 +206,6 @@ const Action = (action, showVotes, annotations) => {
                 return <span key={index}>{annot.label(action)}</span>;
               }
             })}
-
         </div>
       </td>
     </tr>

--- a/src/components/bill/Actions.js
+++ b/src/components/bill/Actions.js
@@ -74,7 +74,6 @@ const highlightRow = css`
 `;
 
 const BillActions = ({ actions, lawsUrl, vetoMemoUrl }) => {
-  console.log(actions)
   const [showMinorActions, setShowMinorActions] = useState(false);
   const [showVotes, setShowVotes] = useState(true);
 


### PR DESCRIPTION
**In this PR:**
1) Add back committee names being displayed for hearings. 
2) Mirrored styling from 2023 guide
3) Will need to add links back once committee pages are fully fixed

![Screenshot 2025-03-12 at 10 52 02 AM](https://github.com/user-attachments/assets/08f96e4e-c0c0-468d-a5a9-c7f053052779)


