### PR TITLE
Stop filtering by isActive for LawmakerLookup.js

### DIFF
--- a/src/components/input/LawmakerLookup.js
+++ b/src/components/input/LawmakerLookup.js
@@ -18,6 +18,7 @@ class LawmakerLookup extends Component {
 
     searchByName(input) {
         const { lawmakers } = this.props;
+        console.log({lawmakers});
         if (input.length < 3) {
             this.setState({
                 lawmakersFound: [],
@@ -53,6 +54,16 @@ class LawmakerLookup extends Component {
     }
 }
 
+const inactiveBadge = css`
+  font-size: 0.7em;
+  background-color: #e74c3c;
+  color: white;
+  padding: 2px 5px;
+  border-radius: 3px;
+  margin-left: 5px;
+  vertical-align: middle;
+`;
+
 const resultContainer = css`
     display: flex;
     flex-wrap: wrap;
@@ -87,18 +98,19 @@ const resultName = css`
 const labelCss = css`margin-bottom: 0.2em;`;
 
 const LawmakerEntry = ({ lawmaker }) => {
-    const { key, title, name, party, district, locale, phone, email } = lawmaker;
+    const { key, title, name, party, district, locale, phone, email, isActive } = lawmaker;
     return (
-        <div css={resultItem}>
-            <div css={resultLabel}>{district.key}</div>
-            <div css={resultName}>
-                <Link href={`/lawmakers/${key}`}>{title} {name}</Link>
-            </div>
-            <div>({party} - {locale})</div>
-            <div><a href={`tel:${cleanPhoneString(phone)}`}>{phone}</a></div>
-            <div><a href={`mailto:${email}`}>{email}</a></div>
+      <div css={resultItem}>
+        <div css={resultLabel}>{district.key}</div>
+        <div css={resultName}>
+          <Link href={`/lawmakers/${key}`}>{title} {name}</Link>
+          {!isActive && <span css={inactiveBadge}>Inactive</span>}
         </div>
+        <div>({party} - {locale})</div>
+        <div><a href={`tel:${cleanPhoneString(phone)}`}>{phone}</a></div>
+        <div><a href={`mailto:${email}`}>{email}</a></div>
+      </div>
     );
-};
+  };
 
 export default LawmakerLookup;

--- a/src/components/input/LawmakerLookup.js
+++ b/src/components/input/LawmakerLookup.js
@@ -18,7 +18,6 @@ class LawmakerLookup extends Component {
 
     searchByName(input) {
         const { lawmakers } = this.props;
-        console.log({lawmakers});
         if (input.length < 3) {
             this.setState({
                 lawmakersFound: [],

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -72,7 +72,7 @@ const Index = ({ keyBills, billIndex, lawmakerIndex }) => {
 export async function getStaticProps() {
   const keyBills = bills.filter(bill => bill.isMajorBill);
   const billIndex = bills;
-  const lawmakerIndex = lawmakers.filter(lawmaker => lawmaker.isActive);
+  const lawmakerIndex = lawmakers;
 
   return {
     props: {


### PR DESCRIPTION
**In this PR:**
1) Remove the `isActive` filtering from getStaticProps in `index.js` that is used for `LawmakerLookup`
2) Added an `Inactive` badge so it's clear to the user. 

![Screenshot 2025-03-13 at 10 42 12 AM](https://github.com/user-attachments/assets/c3b428e9-e135-4336-bc6f-b76862ac336c)
