### PR TITLE
Calendar Tweaks

### DIFF
--- a/process/models/CalendarPage.js
+++ b/process/models/CalendarPage.js
@@ -4,7 +4,6 @@ export default class CalendarPage {
     constructor({ actions, updateTime, calendarAnnotations }) {
         const beginningOfToday = new Date(updateTime).setUTCHours(7, 0, 0, 0) // 7 accounts for Montana vs GMT time
         const formattedBeginningOfToday = dateFormat(new Date(beginningOfToday))
-        console.log({ formattedBeginningOfToday })
 
         // For checking that server is handling dates the same as my local machine
         // console.log({

--- a/src/components/CalendarNavigator.js
+++ b/src/components/CalendarNavigator.js
@@ -130,12 +130,9 @@ const CalendarNavigator = ({ dates, currentPageDate }) => {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
   const isTodayPage = () => {
-    // If currentPageDate is null, we're likely on the default calendar page (today)
     if (currentPageDate === null) {
       return true;
     }
-    
-    // Otherwise, compare the formatted date to today
     const today = new Date();
     const todayKey = formatDateKey(today);
     return currentPageDate === todayKey;
@@ -322,7 +319,6 @@ const CalendarNavigator = ({ dates, currentPageDate }) => {
   `;
 
   const navigationDate = getValidNavigationDate();
-  console.log(navigationDate)
   const { prev, next } = getNavigationDays(dates, navigationDate);
 
   return (

--- a/src/pages/calendar/[key].js
+++ b/src/pages/calendar/[key].js
@@ -40,6 +40,7 @@ const Committee = ({ committee, onCalendarBills, hearings }) => {
 
 export default function CalendarDay({ dateData, onCalendarBills, committees, isInvalidDate, dateStr }) {
     const router = useRouter();
+    console.log(dateData)
 
     // For invalid dates (no legislative activity), show a custom message
     if (isInvalidDate || (dateData.hearings.length === 0 && dateData.floorDebates.length === 0 && dateData.finalVotes.length === 0)) {
@@ -59,7 +60,7 @@ export default function CalendarDay({ dateData, onCalendarBills, committees, isI
                 pageDescription={`Montana legislative calendar for ${formattedDate}`}
             >
                 <h1>Legislative Calendar</h1>
-                
+
                 <div css={css`
                   background: var(--gray2);
                   padding: 1em;
@@ -70,7 +71,7 @@ export default function CalendarDay({ dateData, onCalendarBills, committees, isI
                     <h2>No Legislative Events on {formattedDate}</h2>
                     <p>There are no scheduled legislative events for this date. Please select a date from the calendar below.</p>
                 </div>
-                
+
                 <CalendarNavigator
                     dates={calendar.dates}
                     currentPageDate={null}
@@ -129,11 +130,11 @@ export default function CalendarDay({ dateData, onCalendarBills, committees, isI
                 `}>
                 {dateData.hearings.length > 0 || dateData.floorDebates.length > 0 || dateData.finalVotes.length > 0 ? (
                     <>
-                    <span css={css`color: var(--text);`}>
-                        {dateData.hearings.length} {dateData.hearings.length === 1 ? 'hearing' : 'hearings'}{' '}
-                        • {dateData.floorDebates.length} floor {dateData.floorDebates.length === 1 ? 'debate' : 'debates'}{' '}
-                        • {dateData.finalVotes.length} final {dateData.finalVotes.length === 1 ? 'vote' : 'votes'}
-                    </span>
+                        <span css={css`color: var(--text);`}>
+                            {dateData.hearings.length} {dateData.hearings.length === 1 ? 'hearing' : 'hearings'}{' '}
+                            • {dateData.floorDebates.length} floor {dateData.floorDebates.length === 1 ? 'debate' : 'debates'}{' '}
+                            • {dateData.finalVotes.length} final {dateData.finalVotes.length === 1 ? 'vote' : 'votes'}
+                        </span>
                     </>
                 ) : (
                     <span>No scheduled legislative activity</span>
@@ -190,15 +191,61 @@ export default function CalendarDay({ dateData, onCalendarBills, committees, isI
                         <div className="note">
                             Debates are followed by Second Reading votes.
                         </div>
-                        <BillTable
-                            bills={onCalendarBills.filter(bill =>
-                                dateData.floorDebates
-                                    .map(d => d.data.bill)
-                                    .includes(bill.identifier)
+
+                        {/* House Floor Debates */}
+                        {dateData.floorDebates.some(debate => debate.data.billHolder?.toLowerCase() === "house") && (
+                            <div css={css`margin-bottom: 1.5em;`}>
+                                <h4>🏠 House</h4>
+                                <BillTable
+                                    bills={onCalendarBills.filter(bill =>
+                                        dateData.floorDebates
+                                            .filter(debate => debate.data.billHolder?.toLowerCase() === "house")
+                                            .map(d => d.data.bill)
+                                            .includes(bill.identifier)
+                                    )}
+                                    displayLimit={10}
+                                    suppressCount={true}
+                                />
+                            </div>
+                        )}
+
+                        {/* Senate Floor Debates */}
+                        {dateData.floorDebates.some(debate => debate.data.billHolder?.toLowerCase() === "senate") && (
+                            <div>
+                                <h4>🏛 Senate</h4>
+                                <BillTable
+                                    bills={onCalendarBills.filter(bill =>
+                                        dateData.floorDebates
+                                            .filter(debate => debate.data.billHolder?.toLowerCase() === "senate")
+                                            .map(d => d.data.bill)
+                                            .includes(bill.identifier)
+                                    )}
+                                    displayLimit={10}
+                                    suppressCount={true}
+                                />
+                            </div>
+                        )}
+
+                        {/* Handle debates without a specified chamber */}
+                        {dateData.floorDebates.some(debate => !debate.data.billHolder ||
+                            (debate.data.billHolder.toLowerCase() !== "house" &&
+                                debate.data.billHolder.toLowerCase() !== "senate")) && (
+                                <div css={css`margin-top: 1.5em;`}>
+                                    <h4>Other Floor Debates</h4>
+                                    <BillTable
+                                        bills={onCalendarBills.filter(bill =>
+                                            dateData.floorDebates
+                                                .filter(debate => !debate.data.billHolder ||
+                                                    (debate.data.billHolder.toLowerCase() !== "house" &&
+                                                        debate.data.billHolder.toLowerCase() !== "senate"))
+                                                .map(d => d.data.bill)
+                                                .includes(bill.identifier)
+                                        )}
+                                        displayLimit={10}
+                                        suppressCount={true}
+                                    />
+                                </div>
                             )}
-                            displayLimit={10}
-                            suppressCount={true}
-                        />
                     </>
                 )}
             </section>
@@ -212,15 +259,61 @@ export default function CalendarDay({ dateData, onCalendarBills, committees, isI
                         <div className="note">
                             Final votes determine if a bill advances to the next chamber or to the governor.
                         </div>
-                        <BillTable
-                            bills={onCalendarBills.filter(bill =>
-                                dateData.finalVotes
-                                    .map(d => d.data.bill)
-                                    .includes(bill.identifier)
+
+                        {/* House Final Votes */}
+                        {dateData.finalVotes.some(vote => vote.data.billHolder?.toLowerCase() === "house") && (
+                            <div css={css`margin-bottom: 1.5em;`}>
+                                <h4>🏠 House</h4>
+                                <BillTable
+                                    bills={onCalendarBills.filter(bill =>
+                                        dateData.finalVotes
+                                            .filter(vote => vote.data.billHolder?.toLowerCase() === "house")
+                                            .map(d => d.data.bill)
+                                            .includes(bill.identifier)
+                                    )}
+                                    displayLimit={10}
+                                    suppressCount={true}
+                                />
+                            </div>
+                        )}
+
+                        {/* Senate Final Votes */}
+                        {dateData.finalVotes.some(vote => vote.data.billHolder?.toLowerCase() === "senate") && (
+                            <div>
+                                <h4>🏛 Senate</h4>
+                                <BillTable
+                                    bills={onCalendarBills.filter(bill =>
+                                        dateData.finalVotes
+                                            .filter(vote => vote.data.billHolder?.toLowerCase() === "senate")
+                                            .map(d => d.data.bill)
+                                            .includes(bill.identifier)
+                                    )}
+                                    displayLimit={10}
+                                    suppressCount={true}
+                                />
+                            </div>
+                        )}
+
+                        {/* Handle votes without a specified chamber */}
+                        {dateData.finalVotes.some(vote => !vote.data.billHolder ||
+                            (vote.data.billHolder.toLowerCase() !== "house" &&
+                                vote.data.billHolder.toLowerCase() !== "senate")) && (
+                                <div css={css`margin-top: 1.5em;`}>
+                                    <h4>Other Final Votes</h4>
+                                    <BillTable
+                                        bills={onCalendarBills.filter(bill =>
+                                            dateData.finalVotes
+                                                .filter(vote => !vote.data.billHolder ||
+                                                    (vote.data.billHolder.toLowerCase() !== "house" &&
+                                                        vote.data.billHolder.toLowerCase() !== "senate"))
+                                                .map(d => d.data.bill)
+                                                .includes(bill.identifier)
+                                        )}
+                                        displayLimit={10}
+                                        suppressCount={true}
+                                    />
+                                </div>
                             )}
-                            displayLimit={10}
-                            suppressCount={true}
-                        />
                     </>
                 )}
             </section>

--- a/src/pages/calendar/[key].js
+++ b/src/pages/calendar/[key].js
@@ -40,7 +40,6 @@ const Committee = ({ committee, onCalendarBills, hearings }) => {
 
 export default function CalendarDay({ dateData, onCalendarBills, committees, isInvalidDate, dateStr }) {
     const router = useRouter();
-    console.log(dateData)
 
     // For invalid dates (no legislative activity), show a custom message
     if (isInvalidDate || (dateData.hearings.length === 0 && dateData.floorDebates.length === 0 && dateData.finalVotes.length === 0)) {

--- a/src/pages/lawmaker-cards/[key].js
+++ b/src/pages/lawmaker-cards/[key].js
@@ -28,7 +28,6 @@ export async function getStaticProps({ params }) {
 }
 
 const Lawmaker = ({ lawmaker }) => {
-    console.log(lawmaker)
     if (!lawmaker) {
         return <div>Lawmaker not found</div>;
     }

--- a/src/pages/lawmakers/[key].js
+++ b/src/pages/lawmakers/[key].js
@@ -81,7 +81,6 @@ const LawmakerPage = ({ lawmaker }) => {
     portrait,
   } = lawmaker;
 
-  console.log({ lawmakerPageText })
   return (
     <Layout
       relativePath={`/${key}`}


### PR DESCRIPTION
**In this PR:**
1) `Floor Votes` and `Floor Debates` now get their own House and Senate subsection. 
2) Moved `Prev` `Go to today` & `Next` buttons. 
3) `Go to today` no longer shown when we are already on today. 
4) Small styling tweaks to make the buttons fit in nicely. 
5) `rm` a few console logs. 


![Screenshot 2025-03-13 at 11 47 07 AM](https://github.com/user-attachments/assets/84b1200d-42a6-4013-9180-ae5209649ebf)
![Screenshot 2025-03-13 at 11 47 24 AM](https://github.com/user-attachments/assets/7590d8a6-e675-4190-8c36-593cb358f71e)
