### PR TITLE
Only show `proposed amendments` link for bills with amendments

### DIFF
--- a/src/config/utils.js
+++ b/src/config/utils.js
@@ -67,6 +67,16 @@ export const listToText = (list) => {
   }
 }
 
+export async function fetchBillsWithAmendments() {
+  try {
+    const response = await fetch('/capitol-tracker-2025/bills-with-amendments.txt');
+    const text = await response.text();
+    return text.trim().split('\n');
+  } catch (error) {
+    console.error('Error fetching bills with amendments:', error);
+    return [];
+  }
+}
 // export const sortByIdentifier = (a, b) => {
 // Not working
 //   console.log(a, b)


### PR DESCRIPTION
**In this PR:**
1) Add a util function `fetchBillsWithAmendments`
2) Modify `BillTable.js` to use it so that links only show when there is amendments

**TODO:**
1) Add interface for selecting from the amendment PDFs we are storing on our deployment rather than linking to the state's website tab with that bill's amendments.