### PR TITLE
Canceled hearings

### DIFF
--- a/process/models/CalendarPage.js
+++ b/process/models/CalendarPage.js
@@ -35,7 +35,6 @@ export default class CalendarPage {
             }, {});
 
         const dateMap = actions.reduce((acc, action) => {
-            // Skip the cancellation actions themselves - we'll use the map instead
             if (action.data.description === "Hearing Canceled") return acc;
 
             // check if canceled by key

--- a/process/models/CalendarPage.js
+++ b/process/models/CalendarPage.js
@@ -28,7 +28,7 @@ export default class CalendarPage {
         const canceledHearings = actions
             .filter(action => action.data.description === "Hearing Canceled")
             .reduce((map, action) => {
-                // Create a unique key for this hearing
+                // create unique key for hearing
                 const key = `${action.data.bill}|${action.data.committee}|${action.data.committeeHearingTime}`;
                 map[key] = true;
                 return map;
@@ -38,11 +38,11 @@ export default class CalendarPage {
             // Skip the cancellation actions themselves - we'll use the map instead
             if (action.data.description === "Hearing Canceled") return acc;
 
-            // Check if this hearing has been canceled
+            // check if canceled by key
             if (action.data.committeeHearingTime && action.data.committee) {
                 const hearingKey = `${action.data.bill}|${action.data.committee}|${action.data.committeeHearingTime}`;
                 if (canceledHearings[hearingKey]) {
-                    // Skip this hearing as it was canceled
+                    // skip hearing if canceled
                     return acc;
                 }
             }

--- a/process/models/CalendarPage.js
+++ b/process/models/CalendarPage.js
@@ -25,18 +25,27 @@ export default class CalendarPage {
             return parseDate(a) - parseDate(b);
         };
 
+        const canceledHearings = actions
+            .filter(action => action.data.description === "Hearing Canceled")
+            .reduce((map, action) => {
+                // Create a unique key for this hearing
+                const key = `${action.data.bill}|${action.data.committee}|${action.data.committeeHearingTime}`;
+                map[key] = true;
+                return map;
+            }, {});
+
         const dateMap = actions.reduce((acc, action) => {
-            // Debug floor debates and final votes
-            // if (action.data.scheduledForFloorDebate || action.data.scheduledForFinalVote) {
-            //     console.log('Debug Action:', {
-            //         type: action.data.scheduledForFloorDebate ? 'Floor Debate' : 'Final Vote',
-            //         bill: action.data.bill,
-            //         date: action.data.date,
-            //         description: action.data.description
-            //     });
-            // }
-        
+            // Skip the cancellation actions themselves - we'll use the map instead
             if (action.data.description === "Hearing Canceled") return acc;
+
+            // Check if this hearing has been canceled
+            if (action.data.committeeHearingTime && action.data.committee) {
+                const hearingKey = `${action.data.bill}|${action.data.committee}|${action.data.committeeHearingTime}`;
+                if (canceledHearings[hearingKey]) {
+                    // Skip this hearing as it was canceled
+                    return acc;
+                }
+            }
 
             let date = action.data.committeeHearingTime ||
                 (action.data.isCommitteeAction ? action.data.date : null);
@@ -81,7 +90,7 @@ export default class CalendarPage {
 
             return acc;
         }, {});
-        
+
         // Debug the final dateMap
         // console.log('Final dateMap stats:', {
         //     totalDates: Object.keys(dateMap).length,
@@ -92,51 +101,51 @@ export default class CalendarPage {
         //     sampleDate: Object.values(dateMap)[0]
         // });
 
-         // Generate endpoints for all days in months with valid legislative days
-         const allDates = new Set(Object.keys(dateMap));
-         Object.keys(dateMap).forEach(key => {
-             const [month, , year] = key.split('-').map(Number);
-             const daysInMonth = new Date(year, month, 0).getDate();
-             for (let day = 1; day <= daysInMonth; day++) {
-                 const dayStr = String(day).padStart(2, '0');
-                 const newKey = `${String(month).padStart(2, '0')}-${dayStr}-${year}`;
-                 if (!allDates.has(newKey)) {
-                     allDates.add(newKey);
-                     dateMap[newKey] = {
-                         key: newKey,
-                         date: `${String(month).padStart(2, '0')}/${dayStr}/${year}`,
-                         hearings: [],
-                         floorDebates: [],
-                         finalVotes: [],
-                         annotation: null,
-                         billsInvolved: []
-                     };
-                 }
-             }
-         });
- 
-         const sortedDateKeys = Array.from(allDates)
-             .map(key => dateMap[key].date)
-             .sort(compareDates)
-             .map(date => date.replace(/\//g, '-'));
- 
-         const dates = sortedDateKeys.map(key => ({
-             ...dateMap[key],
-             billsInvolved: dateMap[key].billsInvolved.sort()
-         }));
- 
-         this.data = {
-             dates,
-             dateKeys: sortedDateKeys,
-             dateMap,
-             billsOnCalendar: Array.from(new Set(dates.flatMap(d => d.billsInvolved))).sort(),
-             datesOnCalendar: sortedDateKeys.map(key => key.replace(/-/g, '/')),
-             scheduledHearings: actions.filter(d => d.data.committeeHearingTime),
-             scheduledFloorDebates: actions.filter(d => d.data.scheduledForFloorDebate),
-             scheduledFinalVotes: actions.filter(d => d.data.scheduledForFinalVote),
-             calendarAnnotations
-         };
-     }
- 
-     export = () => ({ ...this.data })
- }
+        // Generate endpoints for all days in months with valid legislative days
+        const allDates = new Set(Object.keys(dateMap));
+        Object.keys(dateMap).forEach(key => {
+            const [month, , year] = key.split('-').map(Number);
+            const daysInMonth = new Date(year, month, 0).getDate();
+            for (let day = 1; day <= daysInMonth; day++) {
+                const dayStr = String(day).padStart(2, '0');
+                const newKey = `${String(month).padStart(2, '0')}-${dayStr}-${year}`;
+                if (!allDates.has(newKey)) {
+                    allDates.add(newKey);
+                    dateMap[newKey] = {
+                        key: newKey,
+                        date: `${String(month).padStart(2, '0')}/${dayStr}/${year}`,
+                        hearings: [],
+                        floorDebates: [],
+                        finalVotes: [],
+                        annotation: null,
+                        billsInvolved: []
+                    };
+                }
+            }
+        });
+
+        const sortedDateKeys = Array.from(allDates)
+            .map(key => dateMap[key].date)
+            .sort(compareDates)
+            .map(date => date.replace(/\//g, '-'));
+
+        const dates = sortedDateKeys.map(key => ({
+            ...dateMap[key],
+            billsInvolved: dateMap[key].billsInvolved.sort()
+        }));
+
+        this.data = {
+            dates,
+            dateKeys: sortedDateKeys,
+            dateMap,
+            billsOnCalendar: Array.from(new Set(dates.flatMap(d => d.billsInvolved))).sort(),
+            datesOnCalendar: sortedDateKeys.map(key => key.replace(/-/g, '/')),
+            scheduledHearings: actions.filter(d => d.data.committeeHearingTime),
+            scheduledFloorDebates: actions.filter(d => d.data.scheduledForFloorDebate),
+            scheduledFinalVotes: actions.filter(d => d.data.scheduledForFinalVote),
+            calendarAnnotations
+        };
+    }
+
+    export = () => ({ ...this.data })
+}


### PR DESCRIPTION
**In this PR:**
1) Add filtering for Canceled hearings so we don't display them on calendar
2) Creates a unique key for the hearing based on bill/committee/hearingTime and compares to actions we are considering adding to calendar. 

Old: 
![Screenshot 2025-03-19 at 10 14 04 AM](https://github.com/user-attachments/assets/f4ef6b5d-f8a2-4930-87a9-a30521d37807)

New:
![Screenshot 2025-03-19 at 10 13 36 AM](https://github.com/user-attachments/assets/29d31acf-d860-45ae-834c-16923e62be72)
