### PR TITLE
Fixes for amendment display

### DIFF
--- a/build-and-deploy.sh
+++ b/build-and-deploy.sh
@@ -1,5 +1,5 @@
 # Build
-npx next build
+npm run build
 
 # Deploy
 aws s3 sync build s3://projects.montanafreepress.org/capitol-tracker-2025 --delete

--- a/public/document-index.json
+++ b/public/document-index.json
@@ -1288,236 +1288,236 @@
     ],
     "HB-2": [
       {
-        "name": "HB-2.002.001.001.health.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.B.001_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.001.k-12-education.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.E.001_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.001.nat-resource-transportation.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.C.001_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.001.O.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.O.001_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.001.public-safety.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.D.001_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.002.health.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.B.002_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.002.k-12-education.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.E.002_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.002.nat-resource-transportation.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.C.002_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.002.O.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.O.002_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.002.public-safety.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.D.002_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.003.general-government.final-full",
+        "name": "HB-2.002.001.A.003.general-government.final-full",
         "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.A.003_Amendments-in-Context_final-full.pdf"
       },
       {
-        "name": "HB-2.002.001.003.health.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.B.003_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.003.k-12-education.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.E.003_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.003.public-safety.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.D.003_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.004.nat-resource-transportation.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.C.004_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.004.O.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.O.004_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.004.public-safety.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.D.004_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.005.health.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.B.005_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.005.k-12-education.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.E.005_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.005.nat-resource-transportation.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.C.005_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.005.O.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.O.005_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.005.public-safety.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.D.005_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.006.health.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.B.006_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.006.public-safety.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.D.006_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.007.health.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.B.007_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.007.nat-resource-transportation.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.C.007_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.007.O.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.O.007_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.007.public-safety.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.D.007_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.008.general-government.final-full",
+        "name": "HB-2.002.001.A.008.general-government.final-full",
         "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.A.008_Amendments-in-Context_final-full.pdf"
       },
       {
-        "name": "HB-2.002.001.008.health.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.B.008_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.008.k-12-education.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.E.008_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.009.general-government.final-full",
+        "name": "HB-2.002.001.A.009.general-government.final-full",
         "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.A.009_Amendments-in-Context_final-full.pdf"
       },
       {
-        "name": "HB-2.002.001.009.health.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.B.009_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.009.k-12-education.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.E.009_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.009.public-safety.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.D.009_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.010.general-government.final-full",
+        "name": "HB-2.002.001.A.010.general-government.final-full",
         "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.A.010_Amendments-in-Context_final-full.pdf"
       },
       {
-        "name": "HB-2.002.001.010.health.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.B.010_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.010.k-12-education.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.E.010_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.010.public-safety.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.D.010_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.011.general-government.final-full",
+        "name": "HB-2.002.001.A.011.general-government.final-full",
         "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.A.011_Amendments-in-Context_final-full.pdf"
       },
       {
-        "name": "HB-2.002.001.011.health.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.B.011_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.011.k-12-education.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.E.011_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.011.public-safety.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.D.011_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.012.general-government.final-full",
+        "name": "HB-2.002.001.A.012.general-government.final-full",
         "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.A.012_Amendments-in-Context_final-full.pdf"
       },
       {
-        "name": "HB-2.002.001.012.public-safety.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.D.012_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.013.general-government.final-full",
+        "name": "HB-2.002.001.A.013.general-government.final-full",
         "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.A.013_Amendments-in-Context_final-full.pdf"
       },
       {
-        "name": "HB-2.002.001.013.health.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.B.013_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.013.k-12-education.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.E.013_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.013.public-safety.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.D.013_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.014.general-government.final-full",
+        "name": "HB-2.002.001.A.014.general-government.final-full",
         "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.A.014_Amendments-in-Context_final-full.pdf"
       },
       {
-        "name": "HB-2.002.001.014.k-12-education.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.E.014_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.015.general-government.final-full",
+        "name": "HB-2.002.001.A.015.general-government.final-full",
         "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.A.015_Amendments-in-Context_final-full.pdf"
       },
       {
-        "name": "HB-2.002.001.015.k-12-education.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.E.015_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.015.public-safety.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.D.015_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.016.k-12-education.final-full",
-        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.E.016_Amendments-in-Context_final-full.pdf"
-      },
-      {
-        "name": "HB-2.002.001.017.general-government.final-full",
+        "name": "HB-2.002.001.A.017.general-government.final-full",
         "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.A.017_Amendments-in-Context_final-full.pdf"
       },
       {
-        "name": "HB-2.002.001.018.general-government.final-full",
+        "name": "HB-2.002.001.A.018.general-government.final-full",
         "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.A.018_Amendments-in-Context_final-full.pdf"
       },
       {
-        "name": "HB-2.002.001.019.general-government.final-full",
+        "name": "HB-2.002.001.A.019.general-government.final-full",
         "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.A.019_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.B.001.health.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.B.001_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.B.002.health.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.B.002_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.B.003.health.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.B.003_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.B.005.health.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.B.005_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.B.006.health.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.B.006_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.B.007.health.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.B.007_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.B.008.health.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.B.008_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.B.009.health.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.B.009_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.B.010.health.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.B.010_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.B.011.health.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.B.011_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.B.013.health.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.B.013_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.C.001.nat-resource-transportation.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.C.001_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.C.002.nat-resource-transportation.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.C.002_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.C.004.nat-resource-transportation.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.C.004_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.C.005.nat-resource-transportation.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.C.005_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.C.007.nat-resource-transportation.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.C.007_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.D.001.public-safety.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.D.001_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.D.002.public-safety.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.D.002_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.D.003.public-safety.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.D.003_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.D.004.public-safety.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.D.004_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.D.005.public-safety.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.D.005_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.D.006.public-safety.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.D.006_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.D.007.public-safety.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.D.007_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.D.009.public-safety.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.D.009_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.D.010.public-safety.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.D.010_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.D.011.public-safety.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.D.011_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.D.012.public-safety.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.D.012_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.D.013.public-safety.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.D.013_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.D.015.public-safety.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.D.015_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.E.001.k-12-education.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.E.001_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.E.002.k-12-education.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.E.002_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.E.003.k-12-education.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.E.003_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.E.005.k-12-education.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.E.005_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.E.008.k-12-education.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.E.008_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.E.009.k-12-education.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.E.009_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.E.010.k-12-education.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.E.010_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.E.011.k-12-education.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.E.011_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.E.013.k-12-education.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.E.013_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.E.014.k-12-education.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.E.014_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.E.015.k-12-education.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.E.015_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.E.016.k-12-education.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.E.016_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.O.001.global-amendment.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.O.001_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.O.002.global-amendment.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.O.002_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.O.004.global-amendment.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.O.004_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.O.005.global-amendment.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.O.005_Amendments-in-Context_final-full.pdf"
+      },
+      {
+        "name": "HB-2.002.001.O.007.global-amendment.final-full",
+        "url": "/capitol-tracker-2025/amendments/HB-2/HB0002.002.001.O.007_Amendments-in-Context_final-full.pdf"
       }
     ],
     "HB-20": [

--- a/scripts/generate-document-index.js
+++ b/scripts/generate-document-index.js
@@ -57,15 +57,15 @@ documentTypes.forEach(type => {
                                     'D': 'public-safety',
                                     'E': 'k-12-education',
                                     'F': 'long-range',
+                                    'O': 'global-amendment'
                                     // Might be `Office of Budget and Program Planning`? 
                                     // TODO: Find out what this is
-                                    // 'O': 'other'
                                 };
 
                                 const sectionName = sectionMap[sectionLetter.toUpperCase()] || sectionLetter;
 
                                 // Add suffix to name if it exists
-                                name = `${prefix}-${billNum}.${major}.${minor}.${amendNum}.${sectionName}.${finalType}${suffix}`;
+                                name = `${prefix}-${billNum}.${major}.${minor}.${sectionLetter}.${amendNum}.${sectionName}.${finalType}${suffix}`;
 
                                 return {
                                     name: name,


### PR DESCRIPTION
1) Using `npm run build` now to ensure that our `generate-document-index` script is run. 
2) Changed regex to keep the letter to make it easier to follow in the legislature while keeping the extra context of a "human-readable" part as well. 