### PR TITLE
Lawmaker image links to lawmaker page

### DIFF
--- a/src/components/LawmakerTable.js
+++ b/src/components/LawmakerTable.js
@@ -125,11 +125,11 @@ const Row = ({ name, party, district, locale, portrait, lawmakers }) => {
             </td>
             <td>
                 {imageUrl && (
-                    <a href={imageUrl} target="_blank" rel="noopener noreferrer">
+                    <Link href={`/lawmakers/${lawmakerUrl(name)}`}>
                         <div css={{ width: '80px', height: '80px', overflow: 'hidden', position: 'relative' }}>
                             <img src={imageUrl} alt={`Portrait of ${name}`} css={{ width: '100%', height: 'auto', position: 'absolute', top: '0' }} />
                         </div>
-                    </a>
+                    </Link>
                 )}
             </td>
         </tr>


### PR DESCRIPTION
**In this PR:**
1) Fix that lawmaker image in `LawmakerTable.js` was a link to a larger version of the image. Now takes reader to lawmakers page. Most readers likely do not care to see a big photo of the lawmaker lol.