### PR TITLE
Calendar tweaks

### DIFF
--- a/src/components/CalendarNavigator.js
+++ b/src/components/CalendarNavigator.js
@@ -4,7 +4,8 @@ import { css } from '@emotion/react';
 import { shortDateWithWeekday } from '../config/utils';
 
 const calendarStyle = css`
-  width: 400px;
+  width: 100%;
+  max-width: 420px;
   margin: 0 auto;
 
   .calendar-header {
@@ -19,6 +20,7 @@ const calendarStyle = css`
       flex: 1;
       display: flex;
       justify-content: center;
+      font-size: 1.2em;
       
       h3 {
         display: flex;
@@ -115,6 +117,18 @@ const calendarStyle = css`
         &:hover {
           background-color: var(--tan2);
           color: var(--link);
+        }
+        
+        &.current {
+          background-color: #ce5a00;
+          color: white;
+          font-weight: bold;
+          font-size: 1.1em;
+          
+          &:hover {
+            background-color: darken(#ce5a00, 10%);
+            color: white;
+          }
         }
       }
     }
@@ -324,15 +338,6 @@ const CalendarNavigator = ({ dates, currentPageDate }) => {
   return (
     <div css={calendarStyle}>
       <div className="calendar-header">
-        <button
-          className="navigation-button"
-          onClick={goToPreviousMonth}
-          disabled={isFirstMonth}
-          title="Previous Month"
-        >
-          ◀
-        </button>
-
         <div className="month-selector">
           <h3
             onClick={() => setIsDropdownOpen(!isDropdownOpen)}
@@ -356,49 +361,55 @@ const CalendarNavigator = ({ dates, currentPageDate }) => {
             </div>
           )}
         </div>
-
-        <button
-          className="navigation-button"
-          onClick={goToNextMonth}
-          disabled={isLastMonth}
-          title="Next Month"
-        >
-          ▶
-        </button>
       </div>
-      <div css={css`
-  display: flex;
-  justify-content: space-between;
-  margin-top: 0em;
-  margin-bottom: .5em;
-  gap: 0.5em;
-`}>
+
+      <div
+        css={css`
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          margin-top: 0em;
+          margin-bottom: 0.5em;
+          gap: 0.5em;
+          min-height: 50px;
+        `}
+      >
         {prev ? (
           <Link href={`/calendar/${prev}`} passHref>
             <button
               className="nav-day-button"
               title="Go to Previous Legislative Day"
               css={css`
-          background-color: var(--gray1);
-          border: 1px solid transparent;
-          border-radius: 4px;
-          padding: 0.2em 0.6em;
-          font-size: 0.85em;
-          font-weight: 600;
-          cursor: pointer;
-          transition: all 0.2s ease;
-          box-sizing: border-box;
-          min-width: 90px;
-          text-align: center;
-          
-          &:hover {
-            background-color: var(--gray2);
-            color: var(--link);
-            border: 1px solid transparent;
-          }
-        `}
+                background: none !important;
+                border: none !important;
+                cursor: pointer;
+                font-size: 1.2em;
+                padding: 0.5em;
+                transition: color 0.2s ease;
+                outline: none !important;
+                box-shadow: none !important;
+
+                &:hover {
+                  color: #ce5a00 !important;
+                  background: none !important;
+                  border: none !important;
+                  outline: none !important;
+                  box-shadow: none !important;
+                }
+
+                &:focus {
+                  outline: none !important;
+                  box-shadow: none !important;
+                }
+
+                &:disabled {
+                  opacity: 0.5;
+                  cursor: not-allowed;
+                  visibility: hidden;
+                }
+              `}
             >
-              ← Prev
+              ◀
             </button>
           </Link>
         ) : (
@@ -406,29 +417,37 @@ const CalendarNavigator = ({ dates, currentPageDate }) => {
         )}
 
         {/* Center section with conditional today button */}
-        <div css={css`min-width: 90px; display: flex; justify-content: center;`}>
+        <div
+          css={css`
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            min-width: 90px;
+          `}
+        >
           {!isTodayPage() && (
             <Link href="/calendar" passHref>
               <button
                 className="today-button"
                 title="Go to Today"
                 css={css`
-            background-color: var(--tan2);
-            border: 1px solid transparent;
-            border-radius: 4px;
-            padding: 0.2em 0.6em;
-            font-size: 0.85em;
-            font-weight: 600;
-            cursor: pointer;
-            transition: all 0.2s ease;
-            box-sizing: border-box;
-            
-            &:hover {
-              background-color: var(--tan3);
-              color: var(--link);
-              border: 1px solid transparent;
-            }
-          `}
+                  background-color: var(--tan2);
+                  border: 1px solid transparent;
+                  border-radius: 4px;
+                  padding: 0.2em 0.6em;
+                  font-size: 0.85em;
+                  font-weight: 600;
+                  cursor: pointer;
+                  transition: all 0.2s ease;
+                  box-sizing: border-box;
+
+                  &:hover {
+                    background-color: var(--tan3);
+                    color: var(--link);
+                    border: 1px solid transparent;
+                  }
+                `}
               >
                 Back to today
               </button>
@@ -442,54 +461,73 @@ const CalendarNavigator = ({ dates, currentPageDate }) => {
               className="nav-day-button"
               title="Go to Next Legislative Day"
               css={css`
-          background-color: var(--gray1);
-          border: 1px solid transparent;
-          border-radius: 4px;
-          padding: 0.2em 0.6em;
-          font-size: 0.85em;
-          font-weight: 600;
-          cursor: pointer;
-          transition: all 0.2s ease;
-          box-sizing: border-box;
-          min-width: 90px;
-          text-align: center;
-          
-          &:hover {
-            background-color: var(--gray2);
-            color: var(--link);
-            border: 1px solid transparent;
-          }
-        `}
+                background: none !important;
+                border: none !important;
+                cursor: pointer;
+                font-size: 1.2em;
+                padding: 0.5em;
+                transition: color 0.2s ease;
+                outline: none !important;
+                box-shadow: none !important;
+
+                &:hover {
+                  color: #ce5a00 !important;
+                  background: none !important;
+                  border: none !important;
+                  outline: none !important;
+                  box-shadow: none !important;
+                }
+
+                &:focus {
+                  outline: none !important;
+                  box-shadow: none !important;
+                }
+
+                &:disabled {
+                  opacity: 0.5;
+                  cursor: not-allowed;
+                  visibility: hidden;
+                }
+              `}
             >
-              Next →
+              ▶
             </button>
           </Link>
         ) : (
           <div css={css`min-width: 90px;`}></div>
         )}
       </div>
+
       <div css={gridStyle}>
         {weekdays.map(day => (
           <div key={day} className="weekday-header">
             {day}
           </div>
         ))}
-        {calendarDays.map((day, index) => (
-          <div
-            key={index}
-            className={`calendar-day ${day?.isActive ? 'active' : 'inactive'}`}
-          >
-            {day && (
-              day.isActive ? (
-                <Link href={`/calendar/${day.key}`}>
-                  {day.day}
-                </Link>
-              ) : (
-                day.day
-              )
-            )}
-          </div>
-        ))}
+        {calendarDays.map((day, index) => {
+          // Check if this day is the currently selected day
+          const isCurrentDay = day && day.key === currentPageDate;
+
+          return (
+            <div
+              key={index}
+              className={`calendar-day ${day?.isActive ? 'active' : 'inactive'}`}
+            >
+              {day && (
+                day.isActive ? (
+                  <Link
+                    href={`/calendar/${day.key}`}
+                    className={isCurrentDay ? 'current' : ''}
+                  >
+                    {day.day}
+                  </Link>
+                ) : (
+                  day.day
+                )
+              )}
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/pages/calendar.js
+++ b/src/pages/calendar.js
@@ -7,7 +7,12 @@ const CalendarRedirect = () => {
 
   useEffect(() => {
     if (!router.isReady) return;
-      
+    
+    if (calendar.mostRecentActiveDay) {
+      router.replace(`/calendar/${calendar.mostRecentActiveDay}`);
+      return;
+    }
+    
     const today = new Date();
     const todayKey = `${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}-${today.getFullYear()}`;
     

--- a/src/pages/calendar/[key].js
+++ b/src/pages/calendar/[key].js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useRouter } from 'next/router';
 import { css } from "@emotion/react";
 import Layout from "../../design/Layout";
@@ -9,7 +9,15 @@ import calendar from "../../data/calendar.json";
 import allBills from "../../data/bills.json";
 import committees from "../../data/committees.json";
 
+
+
 const capitalizeFirstLetter = string => string.charAt(0).toUpperCase() + string.slice(1);
+
+const formatDateForLegMtUrl = (dateStr) => {
+    // MM-DD-YYYY to YYYY-MM-DD for state site
+    const [month, day, year] = dateStr.split('-');
+    return `${year}-${month}-${day}`;
+  };
 
 const groupHearingsByCommittee = hearings => {
     return hearings.reduce((acc, hearing) => {
@@ -38,43 +46,205 @@ const Committee = ({ committee, onCalendarBills, hearings }) => {
     );
 };
 
-export default function CalendarDay({ dateData, onCalendarBills, committees, isInvalidDate, dateStr }) {
+export default function CalendarDay({ dateData, onCalendarBills, committees, isInvalidDate, dateStr, redirectToDate }) {
+    console.log({redirectToDate})
     const router = useRouter();
+    const [isSticky, setIsSticky] = useState(false);
+    const [navHeight, setNavHeight] = useState(88);
+    const headerRef = useRef(null);
+    const observerRef = useRef(null);
 
+    useEffect(() => {
+        // check if date has no activity
+        if ((isInvalidDate || !dateData || 
+            (dateData.hearings.length === 0 && 
+             dateData.floorDebates.length === 0 && 
+             dateData.finalVotes.length === 0)) && 
+            redirectToDate && redirectToDate !== dateStr) {
+            
+            router.replace(`/calendar/${redirectToDate}`);
+        }
+    }, [isInvalidDate, dateData, redirectToDate, dateStr, router]);
+
+    useEffect(() => {
+        
+        // calculate nav height for position of "sticky" header
+        function updateNavHeight() {
+            const navElement = document.querySelector('nav') ||
+                document.querySelector('header nav') ||
+                document.querySelector('[css*="navCss"]');
+
+            if (navElement) {
+                const isMobile = window.innerWidth <= 440;
+                const navRect = navElement.getBoundingClientRect();
+
+                const mobileHeight = navRect.height + 20;
+                const desktopHeight = navRect.height + 5;
+
+                setNavHeight(isMobile ? mobileHeight : desktopHeight);
+
+                document.documentElement.style.setProperty('--nav-height-mobile', `${mobileHeight}px`);
+                document.documentElement.style.setProperty('--nav-height-desktop', `${desktopHeight}px`);
+
+                console.log('Nav measurements:', {
+                    isMobile,
+                    height: navRect.height,
+                    mobileHeight,
+                    desktopHeight
+                });
+            }
+        }
+
+        observerRef.current = new IntersectionObserver(
+            ([entry]) => {
+                setIsSticky(!entry.isIntersecting);
+            },
+            {
+                rootMargin: `-${navHeight}px 0px 0px 0px`,
+                threshold: 0
+            }
+        );
+
+        if (headerRef.current) {
+            observerRef.current.observe(headerRef.current);
+        }
+
+        updateNavHeight();
+        window.addEventListener('resize', updateNavHeight);
+
+        return () => {
+            if (observerRef.current) {
+                observerRef.current.disconnect();
+            }
+            window.removeEventListener('resize', updateNavHeight);
+        };
+    }, [navHeight]);
+
+    const initialHeaderStyle = css``;
+
+    const headerStyle = css`
+        display: flex;
+        justify-content: center;
+        
+        h1 {
+            color: white;
+            background-color: var(--gray5);
+            padding: 0.5em 0.5em;
+            padding-right: 120px;
+            border-radius: 4px;
+            margin: 0 0 0.5em 0;
+            display: flex;
+            align-items: center;
+            width: 100%;
+            max-width: 768px;
+            position: relative;
+            
+            &::before {
+                content: "📅";
+                margin-right: 0.5em;
+            }
+            
+            .back-to-top {
+                position: absolute;
+                right: 10px;
+                top: 50%;
+                transform: translateY(-50%);
+                background-color: transparent;
+                color: var(--link);
+                border: none;
+                padding: 0.3em 0.8em;
+                cursor: pointer;
+                font-size: 0.8em;
+                font-weight: normal;
+                text-transform: none;
+                letter-spacing: normal;
+                
+                /* Desktop-specific smaller size */
+                @media (min-width: 768px) {
+                    font-size: 0.7em;
+                    padding: 0.25em 0.7em;
+                }
+                
+               &:hover {
+                    background-color: transparent;
+                    text-decoration: underline;
+                    color: var(--link);
+                    border: none;
+                }
+            }
+        }
+    `;
+    
+
+    const stickyStyle = css`
+        position: fixed;
+        top: var(--nav-height-desktop, ${navHeight + 20}px);
+        left: 0;
+        right: 0;
+        z-index: 1000;
+        padding: 0;
+        width: 100%;
+
+        display: flex;
+        justify-content: center;
+
+        max-width: 800px;
+        margin-left: auto;
+        margin-right: auto;
+
+        h1 {
+            margin: 0;
+            box-shadow: 0 2px 5px rgba(0,0,0,0.2);
+            width: 100%;
+            max-width: 768px;
+        }
+
+        @media (max-width: 440px) {
+            top: var(--nav-height-mobile, ${navHeight + 65}px); 
+            width: 97%
+        }
+    `;
     // For invalid dates (no legislative activity), show a custom message
-    if (isInvalidDate || (dateData.hearings.length === 0 && dateData.floorDebates.length === 0 && dateData.finalVotes.length === 0)) {
-        // Parse the date for display
-        const [month, day, year] = dateStr.split('-').map(Number);
-        const requestedDate = new Date(year, month - 1, day);
-        const formattedDate = requestedDate.toLocaleDateString('en-US', {
-            month: 'long',
-            day: 'numeric',
-            year: 'numeric'
-        });
+    if (isInvalidDate || (!dateData) || (dateData?.hearings?.length === 0 && dateData?.floorDebates?.length === 0 && dateData?.finalVotes?.length === 0)) {
+        const formattedDate = dateStr ? (() => {
+            const [month, day, year] = dateStr.split('-').map(Number);
+            const requestedDate = new Date(year, month - 1, day);
+            return requestedDate.toLocaleDateString('en-US', {
+                month: 'long', day: 'numeric', year: 'numeric'
+            });
+        })() : "Loading...";
+
+
+
 
         return (
             <Layout
-                relativePath={`/calendar/${dateStr}`}
+                relativePath={`/calendar/${dateStr || ''}`}
                 pageTitle={`Legislative Calendar for ${formattedDate} | MTFP Capitol Tracker`}
                 pageDescription={`Montana legislative calendar for ${formattedDate}`}
             >
-                <h1>Legislative Calendar</h1>
-
-                <div css={css`
-                  background: var(--gray2);
-                  padding: 1em;
-                  margin-bottom: 2em;
-                  border-radius: 4px;
-                  text-align: center;
-                `}>
-                    <h2>No Legislative Events on {formattedDate}</h2>
-                    <p>There are no scheduled legislative events for this date. Please select a date from the calendar below.</p>
+                <div id="calendar-header" css={initialHeaderStyle}>
+                    <h1>Calendar — {!dateData ? "Loading..." : "No Activity"}</h1>
                 </div>
 
-                <CalendarNavigator
-                    dates={calendar.dates}
-                    currentPageDate={null}
-                />
+                {isInvalidDate || (dateData?.hearings?.length === 0 && dateData?.floorDebates?.length === 0 && dateData?.finalVotes?.length === 0) ? (
+                    <>
+                        <div css={css`
+                          background: var(--gray1);
+                          padding: 1em;
+                          margin-bottom: 2em;
+                          border-radius: 4px;
+                          text-align: center;
+                        `}>
+                            <h2>No Legislative Events on {formattedDate}</h2>
+                            <p>There are no scheduled legislative events for this date. Please select a date from the calendar below.</p>
+                        </div>
+                        <CalendarNavigator
+                            dates={calendar.dates}
+                            currentPageDate={null}
+                        />
+                    </>
+                ) : null}
             </Layout>
         );
     }
@@ -82,7 +252,9 @@ export default function CalendarDay({ dateData, onCalendarBills, committees, isI
     if (!dateData) {
         return (
             <Layout>
-                <h1>Loading...</h1>
+                <div css={calendarHeaderStyle}>
+                    <h1>Loading...</h1>
+                </div>
             </Layout>
         );
     }
@@ -112,125 +284,574 @@ export default function CalendarDay({ dateData, onCalendarBills, committees, isI
         ),
     };
 
+    const scrollToTop = () => {
+        window.scrollTo({
+            top: 0,
+            behavior: 'smooth'
+        });
+    };
+
+    const handleAnchorClick = (e, targetId) => {
+        e.preventDefault();
+
+        const targetElement = document.getElementById(targetId);
+        if (targetElement) {
+            const targetPosition = targetElement.getBoundingClientRect().top + window.pageYOffset;
+            // adjust this for extra padding
+            const offset = navHeight + 110;
+
+            // scroll to the right spot
+            window.scrollTo({
+                top: targetPosition - offset,
+                behavior: 'smooth'
+            });
+
+            // update URL without triggering browser scroll
+            window.history.pushState(null, '', `#${targetId}`);
+        }
+    };
+
+    const getCommitteeChamber = (committeeName, committeesData) => {
+        const match = committeesData.find(d => d.name === committeeName);
+        return match?.chamber?.toLowerCase() || 'other';
+    };
+
+
     return (
         <Layout
             relativePath={`/calendar/${dateData.key}`}
-            pageTitle={`Legislative Calendar for ${day} | 2025 MTFP Capitol Tracker`}
+            pageTitle={`Legislative Calendar for ${day} | MTFP Capitol Tracker`}
             pageDescription={`Committee hearings and legislative activity for ${day}`}
         >
-            <h1>Calendar — {day}</h1>
-            <div css={css`
-                background-color: var(--gray1);
-                padding: 0.75em;
-                border-radius: 4px;
-                margin-bottom: 1em;
-                text-align: center;
-                font-weight: 500;
-                `}>
-                {dateData.hearings.length > 0 || dateData.floorDebates.length > 0 || dateData.finalVotes.length > 0 ? (
-                    <>
-                        <span css={css`color: var(--text);`}>
-                            {dateData.hearings.length} {dateData.hearings.length === 1 ? 'hearing' : 'hearings'}{' '}
-                            • {dateData.floorDebates.length} floor {dateData.floorDebates.length === 1 ? 'debate' : 'debates'}{' '}
-                            • {dateData.finalVotes.length} final {dateData.finalVotes.length === 1 ? 'vote' : 'votes'}
-                        </span>
-                    </>
+
+            <div
+                ref={headerRef}
+                id="header-observer"
+                css={css`height: 1px; margin-bottom: -1px;`}
+            />
+
+
+
+            <div css={[headerStyle, isSticky && stickyStyle]}>
+                {isSticky ? (
+                    <h1>
+                        {day}
+                        <button
+                            className="back-to-top"
+                            onClick={scrollToTop}
+                            aria-label="Back to top"
+                        >
+                            Back to top
+                        </button>
+                    </h1>
                 ) : (
-                    <span>No scheduled legislative activity</span>
+                    <h1>{day}</h1>
                 )}
             </div>
+
+            {isSticky && (
+                <div css={css`
+                    height: 60px;
+                    margin-bottom: 0.5em;
+                    
+                    @media (max-width: 768px) {
+                        height: 70px;
+                    }
+                `}></div>
+            )}
+
+<div css={css`
+    background-color: var(--gray1);
+    padding: 0.75em;
+    border-radius: 4px;
+    margin-bottom: 1em;
+    text-align: center;
+    font-weight: 500;
+`}>
+    {dateData.hearings.length > 0 || dateData.floorDebates.length > 0 || dateData.finalVotes.length > 0 ? (
+        <>
+            <div css={css`
+                display: flex;
+                justify-content: space-around;
+                flex-wrap: wrap;
+                max-width: 900px;
+                margin: 0 auto;
+            `}>
+                {/* HOUSE SECTION */}
+                <div css={css`margin: 0.5em 1em;`}>
+                    <div css={css`font-weight: bold; margin-bottom: 0.5em;`}>🏠 House</div>
+                    <div css={css`
+                        display: flex;
+                        align-items: center;
+                        font-size: 1em;
+                    `}>
+                        {/* Hearings */}
+                        <div css={css`
+                            display: flex;
+                            flex-direction: column;
+                            align-items: center;
+                        `}>
+                            <b css={css`color: #ce5a00; margin-bottom: 0.1em;`}> {/* Reduced margin */}
+                                {dateData.hearings.filter(h => getCommitteeChamber(h.data.committee, committees) === 'house').length}
+                            </b>
+                            <a href="#house-hearings"
+                                onClick={(e) => handleAnchorClick(e, 'house-hearings')}
+                                css={css`
+                                    text-decoration: none;
+                                    &:hover { color: #ce5a00; }
+                                `}>
+                                Hearings
+                            </a>
+                        </div>
+                        
+                        {/* Bullet separator - centered */}
+                        <span css={css`
+                            margin: 0 0.8em;
+                            color: #ce5a00;
+                            align-self: center;
+                            position: relative;
+                            top: -0.1em; /* Slight adjustment to center with text */
+                        `}>•</span>
+                        
+                        {/* Floor Debates */}
+                        <div css={css`
+                            display: flex;
+                            flex-direction: column;
+                            align-items: center;
+                        `}>
+                            <b css={css`color: #ce5a00; margin-bottom: 0.1em;`}> {/* Reduced margin */}
+                                {dateData.floorDebates?.filter(debate => debate.data.billHolder?.toLowerCase() === "house").length || 0}
+                            </b>
+                            <a href="#house-debates"
+                                onClick={(e) => handleAnchorClick(e, 'house-debates')}
+                                css={css`
+                                    text-decoration: none;
+                                    display: flex;
+                                    flex-direction: column;
+                                    line-height: 0.85; /* Further tightened line spacing */
+                                    text-align: center;
+                                    &:hover { color: #ce5a00; }
+                                `}>
+                                <span>Floor</span>
+                                <span>Debates</span>
+                            </a>
+                        </div>
+                        
+                        {/* Bullet separator - centered */}
+                        <span css={css`
+                            margin: 0 0.8em;
+                            color: #ce5a00;
+                            align-self: center;
+                            position: relative;
+                            top: -0.1em; /* Slight adjustment to center with text */
+                        `}>•</span>
+                        
+                        {/* Floor Votes */}
+                        <div css={css`
+                            display: flex;
+                            flex-direction: column;
+                            align-items: center;
+                        `}>
+                            <b css={css`color: #ce5a00; margin-bottom: 0.1em;`}> {/* Reduced margin */}
+                                {dateData.finalVotes?.filter(vote => vote.data.billHolder?.toLowerCase() === "house").length || 0}
+                            </b>
+                            <a href="#house-votes"
+                                onClick={(e) => handleAnchorClick(e, 'house-votes')}
+                                css={css`
+                                    text-decoration: none;
+                                    display: flex;
+                                    flex-direction: column;
+                                    line-height: 0.85; /* Further tightened line spacing */
+                                    text-align: center;
+                                    &:hover { color: #ce5a00; }
+                                `}>
+                                <span>Floor</span>
+                                <span>Votes</span>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+                
+                {/* SENATE SECTION - with the same spacing adjustments */}
+                <div css={css`margin: 0.5em 1em;`}>
+                    <div css={css`font-weight: bold; margin-bottom: 0.5em;`}>🏛 Senate</div>
+                    <div css={css`
+                        display: flex;
+                        align-items: center;
+                        font-size: 1em;
+                    `}>
+                        {/* Hearings */}
+                        <div css={css`
+                            display: flex;
+                            flex-direction: column;
+                            align-items: center;
+                        `}>
+                            <b css={css`color: #ce5a00; margin-bottom: 0.1em;`}> {/* Reduced margin */}
+                                {dateData.hearings.filter(h => getCommitteeChamber(h.data.committee, committees) === 'senate').length}
+                            </b>
+                            <a href="#senate-hearings"
+                                onClick={(e) => handleAnchorClick(e, 'senate-hearings')}
+                                css={css`
+                                    text-decoration: none;
+                                    &:hover { color: #ce5a00; }
+                                `}>
+                                Hearings
+                            </a>
+                        </div>
+                        
+                        {/* Bullet separator - centered */}
+                        <span css={css`
+                            margin: 0 0.8em;
+                            color: #ce5a00;
+                            align-self: center;
+                            position: relative;
+                            top: -0.1em; /* Slight adjustment to center with text */
+                        `}>•</span>
+                        
+                        {/* Floor Debates */}
+                        <div css={css`
+                            display: flex;
+                            flex-direction: column;
+                            align-items: center;
+                        `}>
+                            <b css={css`color: #ce5a00; margin-bottom: 0.04em;`}> {/* Reduced margin */}
+                                {dateData.floorDebates?.filter(debate => debate.data.billHolder?.toLowerCase() === "senate").length || 0}
+                            </b>
+                            <a href="#senate-debates"
+                                onClick={(e) => handleAnchorClick(e, 'senate-debates')}
+                                css={css`
+                                    text-decoration: none;
+                                    display: flex;
+                                    flex-direction: column;
+                                    line-height: 0.85; /* Further tightened line spacing */
+                                    text-align: center;
+                                    &:hover { color: #ce5a00; }
+                                `}>
+                                <span>Floor</span>
+                                <span>Debates</span>
+                            </a>
+                        </div>
+                        
+                        {/* Bullet separator - centered */}
+                        <span css={css`
+                            margin: 0 0.8em;
+                            color: #ce5a00;
+                            align-self: center;
+                            position: relative;
+                            top: -0.1em; /* Slight adjustment to center with text */
+                        `}>•</span>
+                        
+                        {/* Floor Votes */}
+                        <div css={css`
+                            display: flex;
+                            flex-direction: column;
+                            align-items: center;
+                        `}>
+                            <b css={css`color: #ce5a00; margin-bottom: 0.04em;`}>
+                                {dateData.finalVotes?.filter(vote => vote.data.billHolder?.toLowerCase() === "senate").length || 0}
+                            </b>
+                            <a href="#senate-votes"
+                                onClick={(e) => handleAnchorClick(e, 'senate-votes')}
+                                css={css`
+                                    text-decoration: none;
+                                    display: flex;
+                                    flex-direction: column;
+                                    line-height: 0.85; /* Further tightened line spacing */
+                                    text-align: center;
+                                    &:hover { color: #ce5a00; }
+                                `}>
+                                <span>Floor</span>
+                                <span>Votes</span>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </>
+    ) : (
+        <span>No scheduled legislative activity</span>
+    )}
+</div>
 
             <CalendarNavigator
                 dates={calendar.dates}
                 currentPageDate={dateData.key}
             />
 
-            <section>
-                <h3>Committee Hearings</h3>
-                <div className="note">
-                    Bill hearings allow the sponsor to explain a bill and enable public testimony.
-                </div>
-                {dateData.hearings.length === 0 ? (
-                    <p>No committee hearings scheduled for this date.</p>
-                ) : (
-                    Object.entries(categories).map(([key, categoryCommittees]) => {
-                        if (categoryCommittees.length > 0) {
-                            const title = {
-                                amPolicyCommittees: "Morning Policy Committees",
-                                pmPolicyCommittees: "Afternoon Policy Committees",
-                                appropsCommittees: "Budget Committees",
-                                otherCommittees: "Other Committees",
-                            }[key];
-
-                            return (
-                                <div key={key}>
-                                    <h4>{title}</h4>
-                                    {categoryCommittees.map((committee) => (
-                                        <Committee
-                                            key={`${day}-${committee.name}`}
-                                            committee={committee.name}
-                                            hearings={dateData.hearings}
-                                            onCalendarBills={onCalendarBills}
-                                        />
-                                    ))}
-                                </div>
-                            );
+            <div css={css`
+                text-align: center;
+                margin: 1em 0 1.5em;
+            `}>
+                <a 
+                    href={`https://www.legmt.gov/events/${formatDateForLegMtUrl(dateData.key)}/`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    css={css`
+                        display: inline-flex;
+                        align-items: center;
+                        background-color: var(--gray1);
+                        color: var(--link);
+                        padding: 0.5em 1em;
+                        border-radius: 4px;
+                        text-decoration: none;
+                        font-weight: 500;
+                        transition: all 0.2s ease;
+                        
+                        &:hover {
+                            background-color: var(--gray2);
+                            text-decoration: none; /* Remove default underline */
                         }
-                        return null;
-                    })
-                )}
+                        
+                        &::before {
+                            content: "🔗";
+                            margin-right: 0.5em;
+                        }
+                    `}
+                >
+                    <span css={css`
+                        &:hover {
+                            text-decoration: underline;
+                        }
+                    `}>Official Legislature Calendar</span>
+                </a>
+            </div>
+            <section id="house" css={css`margin-bottom: 3em;`}>
+                <h2 css={css`
+                border-bottom: 2px solid var(--gray3);
+                padding-bottom: 0.5em;
+                margin-bottom: 1em;
+            `}>🏠 House</h2>
+
+                {/* House Hearings */}
+                <section id="house-hearings">
+                    <h3>Committee Hearings</h3>
+                    <div className="note">
+                        Bill hearings allow the sponsor to explain a bill and enable public testimony.
+                    </div>
+                    {dateData.hearings.filter(h => getCommitteeChamber(h.data.committee, committees) === 'house').length === 0 ? (
+                        <p>No House committee hearings scheduled for this date.</p>
+                    ) : (
+                        // filter committees by House chamber
+                        Object.entries({
+                            amPolicyCommittees: committeesWithHearings
+                                .filter(d => d.cat === "morning-policy" && getCommitteeChamber(d.name, committees) === 'house'),
+                            pmPolicyCommittees: committeesWithHearings
+                                .filter(d => d.cat === "afternoon-policy" && getCommitteeChamber(d.name, committees) === 'house'),
+                            appropsCommittees: committeesWithHearings
+                                .filter(d => ["morning-fiscal-sub", "varies-fiscal"].includes(d.cat) &&
+                                    getCommitteeChamber(d.name, committees) === 'house'),
+                            otherCommittees: committeesWithHearings
+                                .filter(d => !["morning-policy", "afternoon-policy", "morning-fiscal-sub", "varies-fiscal"].includes(d.cat) &&
+                                    getCommitteeChamber(d.name, committees) === 'house')
+                        }).map(([key, categoryCommittees]) => {
+                            if (categoryCommittees.length > 0) {
+                                const title = {
+                                    amPolicyCommittees: "Morning Policy Committees",
+                                    pmPolicyCommittees: "Afternoon Policy Committees",
+                                    appropsCommittees: "Budget Committees",
+                                    otherCommittees: "Other Committees",
+                                }[key];
+
+                                return (
+                                    <div key={key}>
+                                        <h4>{title}</h4>
+                                        {categoryCommittees.map((committee) => (
+                                            <Committee
+                                                key={`${day}-${committee.name}`}
+                                                committee={committee.name}
+                                                hearings={dateData.hearings}
+                                                onCalendarBills={onCalendarBills}
+                                            />
+                                        ))}
+                                    </div>
+                                );
+                            }
+                            return null;
+                        })
+                    )}
+                </section>
+
+                {/* House Floor Debates */}
+                <section id="house-debates">
+                    <h3>Floor Debates</h3>
+                    {!dateData.floorDebates?.some(debate => debate.data.billHolder?.toLowerCase() === "house") ? (
+                        <p>No House floor debates scheduled for this date.</p>
+                    ) : (
+                        <>
+                            <div className="note">
+                                Debates are followed by Second Reading votes.
+                            </div>
+                            <BillTable
+                                bills={onCalendarBills.filter(bill =>
+                                    dateData.floorDebates
+                                        .filter(debate => debate.data.billHolder?.toLowerCase() === "house")
+                                        .map(d => d.data.bill)
+                                        .includes(bill.identifier)
+                                )}
+                                displayLimit={10}
+                                suppressCount={true}
+                            />
+                        </>
+                    )}
+                </section>
+
+                {/* House Final Votes */}
+                <section id="house-votes">
+                    <h3>Final Votes</h3>
+                    {!dateData.finalVotes?.some(vote => vote.data.billHolder?.toLowerCase() === "house") ? (
+                        <p>No House final votes scheduled for this date.</p>
+                    ) : (
+                        <>
+                            <div className="note">
+                                Final votes determine if a bill advances to the next chamber or to the governor.
+                            </div>
+                            <BillTable
+                                bills={onCalendarBills.filter(bill =>
+                                    dateData.finalVotes
+                                        .filter(vote => vote.data.billHolder?.toLowerCase() === "house")
+                                        .map(d => d.data.bill)
+                                        .includes(bill.identifier)
+                                )}
+                                displayLimit={10}
+                                suppressCount={true}
+                            />
+                        </>
+                    )}
+                </section>
             </section>
 
-            <section>
-                <h3>Floor Debates</h3>
-                {!dateData.floorDebates?.length ? (
-                    <p>No floor debates scheduled for this date.</p>
-                ) : (
-                    <>
-                        <div className="note">
-                            Debates are followed by Second Reading votes.
-                        </div>
+            {/* SENATE SECTION */}
+            <section id="senate" css={css`margin-bottom: 3em;`}>
+                <h2 css={css`
+                border-bottom: 2px solid var(--gray3);
+                padding-bottom: 0.5em;
+                margin-bottom: 1em;
+            `}>🏛 Senate</h2>
 
-                        {/* House Floor Debates */}
-                        {dateData.floorDebates.some(debate => debate.data.billHolder?.toLowerCase() === "house") && (
-                            <div css={css`margin-bottom: 1.5em;`}>
-                                <h4>🏠 House</h4>
-                                <BillTable
-                                    bills={onCalendarBills.filter(bill =>
-                                        dateData.floorDebates
-                                            .filter(debate => debate.data.billHolder?.toLowerCase() === "house")
-                                            .map(d => d.data.bill)
-                                            .includes(bill.identifier)
-                                    )}
-                                    displayLimit={10}
-                                    suppressCount={true}
-                                />
+                {/* Senate Hearings */}
+                <section id="senate-hearings">
+                    <h3>Committee Hearings</h3>
+                    <div className="note">
+                        Bill hearings allow the sponsor to explain a bill and enable public testimony.
+                    </div>
+                    {dateData.hearings.filter(h => getCommitteeChamber(h.data.committee, committees) === 'senate').length === 0 ? (
+                        <p>No Senate committee hearings scheduled for this date.</p>
+                    ) : (
+                        // filter committees by Senate chamber
+                        Object.entries({
+                            amPolicyCommittees: committeesWithHearings
+                                .filter(d => d.cat === "morning-policy" && getCommitteeChamber(d.name, committees) === 'senate'),
+                            pmPolicyCommittees: committeesWithHearings
+                                .filter(d => d.cat === "afternoon-policy" && getCommitteeChamber(d.name, committees) === 'senate'),
+                            appropsCommittees: committeesWithHearings
+                                .filter(d => ["morning-fiscal-sub", "varies-fiscal"].includes(d.cat) &&
+                                    getCommitteeChamber(d.name, committees) === 'senate'),
+                            otherCommittees: committeesWithHearings
+                                .filter(d => !["morning-policy", "afternoon-policy", "morning-fiscal-sub", "varies-fiscal"].includes(d.cat) &&
+                                    getCommitteeChamber(d.name, committees) === 'senate')
+                        }).map(([key, categoryCommittees]) => {
+                            if (categoryCommittees.length > 0) {
+                                const title = {
+                                    amPolicyCommittees: "Morning Policy Committees",
+                                    pmPolicyCommittees: "Afternoon Policy Committees",
+                                    appropsCommittees: "Budget Committees",
+                                    otherCommittees: "Other Committees",
+                                }[key];
+
+                                return (
+                                    <div key={key}>
+                                        <h4>{title}</h4>
+                                        {categoryCommittees.map((committee) => (
+                                            <Committee
+                                                key={`${day}-${committee.name}`}
+                                                committee={committee.name}
+                                                hearings={dateData.hearings}
+                                                onCalendarBills={onCalendarBills}
+                                            />
+                                        ))}
+                                    </div>
+                                );
+                            }
+                            return null;
+                        })
+                    )}
+                </section>
+
+                {/* Senate Floor Debates */}
+                <section id="senate-debates">
+                    <h3>Floor Debates</h3>
+                    {!dateData.floorDebates?.some(debate => debate.data.billHolder?.toLowerCase() === "senate") ? (
+                        <p>No Senate floor debates scheduled for this date.</p>
+                    ) : (
+                        <>
+                            <div className="note">
+                                Debates are followed by Second Reading votes.
                             </div>
+                            <BillTable
+                                bills={onCalendarBills.filter(bill =>
+                                    dateData.floorDebates
+                                        .filter(debate => debate.data.billHolder?.toLowerCase() === "senate")
+                                        .map(d => d.data.bill)
+                                        .includes(bill.identifier)
+                                )}
+                                displayLimit={10}
+                                suppressCount={true}
+                            />
+                        </>
+                    )}
+                </section>
+
+                {/* Senate Final Votes */}
+                <section id="senate-votes">
+                    <h3>Final Votes</h3>
+                    {!dateData.finalVotes?.some(vote => vote.data.billHolder?.toLowerCase() === "senate") ? (
+                        <p>No Senate final votes scheduled for this date.</p>
+                    ) : (
+                        <>
+                            <div className="note">
+                                Final votes determine if a bill advances to the next chamber or to the governor.
+                            </div>
+                            <BillTable
+                                bills={onCalendarBills.filter(bill =>
+                                    dateData.finalVotes
+                                        .filter(vote => vote.data.billHolder?.toLowerCase() === "senate")
+                                        .map(d => d.data.bill)
+                                        .includes(bill.identifier)
+                                )}
+                                displayLimit={10}
+                                suppressCount={true}
+                            />
+                        </>
+                    )}
+                </section>
+            </section>
+
+            {/* OTHER SECTION (for items without a clear chamber) */}
+            {(dateData.hearings.some(h => getCommitteeChamber(h.data.committee, committees) === 'other') ||
+                dateData.floorDebates.some(d => !d.data.billHolder ||
+                    (d.data.billHolder.toLowerCase() !== "house" && d.data.billHolder.toLowerCase() !== "senate")) ||
+                dateData.finalVotes.some(v => !v.data.billHolder ||
+                    (v.data.billHolder.toLowerCase() !== "house" && v.data.billHolder.toLowerCase() !== "senate"))) && (
+                    <section id="other" css={css`margin-bottom: 3em;`}>
+                        <h2 css={css`
+                    border-bottom: 2px solid var(--gray3);
+                    padding-bottom: 0.5em;
+                    margin-bottom: 1em;
+                `}>Other Events</h2>
+
+                        {/* Other hearings */}
+                        {dateData.hearings.some(h => getCommitteeChamber(h.data.committee, committees) === 'other') && (
+                            <section id="other-hearings">
+                                <h3>Committee Hearings</h3>
+                                {/* Similar structure to the committees above, but for 'other' chamber */}
+                            </section>
                         )}
 
-                        {/* Senate Floor Debates */}
-                        {dateData.floorDebates.some(debate => debate.data.billHolder?.toLowerCase() === "senate") && (
-                            <div>
-                                <h4>🏛 Senate</h4>
-                                <BillTable
-                                    bills={onCalendarBills.filter(bill =>
-                                        dateData.floorDebates
-                                            .filter(debate => debate.data.billHolder?.toLowerCase() === "senate")
-                                            .map(d => d.data.bill)
-                                            .includes(bill.identifier)
-                                    )}
-                                    displayLimit={10}
-                                    suppressCount={true}
-                                />
-                            </div>
-                        )}
-
-                        {/* Handle debates without a specified chamber */}
-                        {dateData.floorDebates.some(debate => !debate.data.billHolder ||
-                            (debate.data.billHolder.toLowerCase() !== "house" &&
-                                debate.data.billHolder.toLowerCase() !== "senate")) && (
-                                <div css={css`margin-top: 1.5em;`}>
-                                    <h4>Other Floor Debates</h4>
+                        {/* Other floor debates */}
+                        {dateData.floorDebates.some(d => !d.data.billHolder ||
+                            (d.data.billHolder.toLowerCase() !== "house" && d.data.billHolder.toLowerCase() !== "senate")) && (
+                                <section id="other-debates">
+                                    <h3>Floor Debates</h3>
                                     <BillTable
                                         bills={onCalendarBills.filter(bill =>
                                             dateData.floorDebates
@@ -243,62 +864,14 @@ export default function CalendarDay({ dateData, onCalendarBills, committees, isI
                                         displayLimit={10}
                                         suppressCount={true}
                                     />
-                                </div>
+                                </section>
                             )}
-                    </>
-                )}
-            </section>
 
-            <section>
-                <h3>Final Votes</h3>
-                {!dateData.finalVotes?.length ? (
-                    <p>No final votes scheduled for this date.</p>
-                ) : (
-                    <>
-                        <div className="note">
-                            Final votes determine if a bill advances to the next chamber or to the governor.
-                        </div>
-
-                        {/* House Final Votes */}
-                        {dateData.finalVotes.some(vote => vote.data.billHolder?.toLowerCase() === "house") && (
-                            <div css={css`margin-bottom: 1.5em;`}>
-                                <h4>🏠 House</h4>
-                                <BillTable
-                                    bills={onCalendarBills.filter(bill =>
-                                        dateData.finalVotes
-                                            .filter(vote => vote.data.billHolder?.toLowerCase() === "house")
-                                            .map(d => d.data.bill)
-                                            .includes(bill.identifier)
-                                    )}
-                                    displayLimit={10}
-                                    suppressCount={true}
-                                />
-                            </div>
-                        )}
-
-                        {/* Senate Final Votes */}
-                        {dateData.finalVotes.some(vote => vote.data.billHolder?.toLowerCase() === "senate") && (
-                            <div>
-                                <h4>🏛 Senate</h4>
-                                <BillTable
-                                    bills={onCalendarBills.filter(bill =>
-                                        dateData.finalVotes
-                                            .filter(vote => vote.data.billHolder?.toLowerCase() === "senate")
-                                            .map(d => d.data.bill)
-                                            .includes(bill.identifier)
-                                    )}
-                                    displayLimit={10}
-                                    suppressCount={true}
-                                />
-                            </div>
-                        )}
-
-                        {/* Handle votes without a specified chamber */}
-                        {dateData.finalVotes.some(vote => !vote.data.billHolder ||
-                            (vote.data.billHolder.toLowerCase() !== "house" &&
-                                vote.data.billHolder.toLowerCase() !== "senate")) && (
-                                <div css={css`margin-top: 1.5em;`}>
-                                    <h4>Other Final Votes</h4>
+                        {/* Other final votes */}
+                        {dateData.finalVotes.some(v => !v.data.billHolder ||
+                            (v.data.billHolder.toLowerCase() !== "house" && v.data.billHolder.toLowerCase() !== "senate")) && (
+                                <section id="other-votes">
+                                    <h3>Final Votes</h3>
                                     <BillTable
                                         bills={onCalendarBills.filter(bill =>
                                             dateData.finalVotes
@@ -311,11 +884,10 @@ export default function CalendarDay({ dateData, onCalendarBills, committees, isI
                                         displayLimit={10}
                                         suppressCount={true}
                                     />
-                                </div>
+                                </section>
                             )}
-                    </>
+                    </section>
                 )}
-            </section>
         </Layout>
     );
 }
@@ -336,9 +908,10 @@ export async function getStaticProps({ params }) {
         return {
             props: {
                 isInvalidDate: true,
-                dateStr: params.key,
+                dateStr: params.key, 
                 committees: committees || [],
-                onCalendarBills: []
+                onCalendarBills: [],
+                redirectToDate: calendar.mostRecentActiveDay
             }
         };
     }
@@ -347,13 +920,20 @@ export async function getStaticProps({ params }) {
         dateData.billsInvolved.includes(bill.identifier)
     );
 
+    // check if this date has any legislative activity
+    const hasActivity = dateData.hearings.length > 0 || 
+                       dateData.floorDebates.length > 0 || 
+                       dateData.finalVotes.length > 0;
+
     return {
         props: {
             dateData,
             onCalendarBills,
             committees: committees || [],
             isInvalidDate: false,
-            dateStr: params.key
+            dateStr: params.key,
+            // set redirectToDate if this day has no activity
+            redirectToDate: hasActivity ? null : calendar.mostRecentActiveDay
         }
     };
 }


### PR DESCRIPTION
**In this PR**
1) Split anchor links and sorting to split house and senate in to their own sections to make things easier 
![Screenshot 2025-04-07 at 11 25 20 AM](https://github.com/user-attachments/assets/d016f4a8-3688-4313-8813-79b97aeb1dde)
2) Added a link to the official legislative calendar
![Screenshot 2025-04-07 at 11 29 16 AM](https://github.com/user-attachments/assets/0e33516f-5ecc-43cc-b461-17779419e4b4)
3) Added processing so we automatically redirect to the last valid legislative day with actions (including today)
4) Tweaked position of nav arrows slightly so they align with the `back to today` button better. 
5) Got rid of confusing month navigation arrows, now the arrows just do next/previous day. 

**To Do in next PR:**
Fix committee sorting, going to be a larger project that will touch committees and want these changes in now to improve user experience 
