### PR TITLE
Fix Committees Calendar Display

### DIFF
--- a/process/main.js
+++ b/process/main.js
@@ -79,19 +79,19 @@ const senateFloorVotes = votes.filter(v => v.voteLocation === 'floor' && v.voteC
 const houseFloorVoteAnalysis = new VotingAnalysis({ votes: houseFloorVotes })
 const senateFloorVoteAnalysis = new VotingAnalysis({ votes: senateFloorVotes })
 
-// const committees = committeesRaw
-//     .filter(d => ![
-//         'conference',
-//         'select',
-//         'procedural',
-//         // 'fiscal-sub'
-//     ].includes(d.type))
-//     .map(schema => new Committee({
-//         schema,
-//         committeeBills: bills.filter(b => b.committees.includes(schema.displayName)),
-//         lawmakers: lawmakers.filter(l => l.data.committees.map(d => d.committee).includes(schema.name)), // Cleaner to do this backwards -- assign lawmakers based on committee data?
-//         updateTime
-//     }))
+const committees = committeesRaw
+    .filter(d => ![
+        'conference',
+        'select',
+        'procedural',
+        // 'fiscal-sub'
+    ].includes(d.type))
+    .map(schema => new Committee({
+        schema,
+        committeeBills: bills.filter(b => b.committees.includes(schema.displayName)),
+        lawmakers: lawmakers.filter(l => l.data.committees.map(d => d.committee).includes(schema.name)), // Cleaner to do this backwards -- assign lawmakers based on committee data?
+        updateTime
+    }))
 
 // Calculations that need both lawmakers and bills populated
 lawmakers.forEach(lawmaker => {
@@ -176,8 +176,8 @@ writeJson('./src/data/bills.json', billsOutput)
 
 const lawmakerOutput = lawmakers.map(l => l.exportMerged())
 writeJson('./src/data/lawmakers.json', lawmakerOutput)
-// const committeeOutput = committees.map(l => l.export())
-// writeJson('./src/data/committees.json', committeeOutput)
+const committeeOutput = committees.map(l => l.export())
+writeJson('./src/data/committees.json', committeeOutput)
 
 writeJson('./src/data/header.json', headerOutput)
 writeJson('./src/data/articles.json', articles)

--- a/process/models/Committee.js
+++ b/process/models/Committee.js
@@ -1,4 +1,3 @@
-
 import { dateParse } from '../functions.js'
 
 
@@ -16,7 +15,9 @@ export default class Committee {
             type
         } = schema;
 
-        const addressKey = displayName.toLowerCase().replace(/\s+/g, '-'); // Dynamically generate the key
+        const addressKey = displayName.toLowerCase()
+            .replace(/[,\.&;:()]/g, '')
+            .replace(/\s+/g, '-');
 
         const beginningOfToday = new Date(updateTime).setUTCHours(7, 0, 0, 0) // 7 accounts for Montana vs GMT time
 
@@ -31,6 +32,10 @@ export default class Committee {
         committeeBills.forEach(bill => {
             const billActions = bill.actions.map(a => a.export())
             const billActionsInCommittee = billActions.filter(a => a.committee === commiteeKey)
+
+            // Skip processing if there are no actions for this bill in this committee
+            if (billActionsInCommittee.length === 0) return;
+
             const lastCommitteeActionIndex = billActions.findIndex(a => a.id === billActionsInCommittee.slice(-1)[0].id)
             const postCommitteeActions = billActions
                 .slice(lastCommitteeActionIndex + 1,)


### PR DESCRIPTION
**In this PR:**
1) Committee data is now being processed and built again 🎉 
2) Fix processing of committees so now commas are removed 
ie no more: `senate,-business,-and-labor` just `senate-business-and-labor`
3) Fixes sorting of committees into AM/PM buckets