### PR TITLE
House blast motion pass threshold

### DIFF
--- a/process/main.js
+++ b/process/main.js
@@ -126,6 +126,8 @@ lawmakers.forEach(lawmaker => {
 const allActions = bills.flatMap(bill => bill.actions);
 const calendarOutput = new CalendarPage({ actions: allActions, bills, updateTime }).export();
 bills.forEach(bill => bill.data.isOnCalendar = calendarOutput.billsOnCalendar.includes(bill.data.identifier))
+// Manual handling for house blast motions and their 55 vote majority requirement 
+// Senate is bare majority for 2025 session
 bills.forEach(bill => {
     bill.actions.forEach(action => {
       const actionData = action.data;
@@ -134,7 +136,7 @@ bills.forEach(bill => {
           actionData.description === 'Taken from Committee; Placed on 2nd Reading' && 
           action.vote.data.count.Y < 55) {
         
-        console.log(`Fixing House blast motion for ${bill.identifier}: ${actionData.id}`);
+        // console.log(`Fixing House blast motion for ${bill.identifier}: ${actionData.id}`);
         // Force override to enforce 55-vote constitutional majority requirement
         action.vote.data.motionPassed = false;
       }

--- a/process/main.js
+++ b/process/main.js
@@ -53,6 +53,18 @@ const contactUsComponentText = getText('./inputs/annotations/components/about.md
 
 const articles = articlesRaw.map(article => new Article({ article }).export())
 
+// actionsFlat.forEach(action => {
+//     // Apply special House blast motion rule
+//     if (action.vote && 
+//         action.vote.voteChamber === "house" && 
+//         action.vote.motion === "Taken from Committee; Placed on 2nd Reading" && 
+//         action.vote.count.Y < 55) {
+      
+//       // Force override to false if it doesn't meet the 55-vote requirement
+//       action.vote.motionPassed = false;
+//     }
+//   });
+
 /// do lawmakers first, then bills
 const lawmakers = lawmakersRaw.map(lawmaker => new Lawmaker({
     lawmaker,
@@ -114,6 +126,21 @@ lawmakers.forEach(lawmaker => {
 const allActions = bills.flatMap(bill => bill.actions);
 const calendarOutput = new CalendarPage({ actions: allActions, bills, updateTime }).export();
 bills.forEach(bill => bill.data.isOnCalendar = calendarOutput.billsOnCalendar.includes(bill.data.identifier))
+bills.forEach(bill => {
+    bill.actions.forEach(action => {
+      const actionData = action.data;
+      if (action.vote && 
+          actionData.billHolder === 'house' && 
+          actionData.description === 'Taken from Committee; Placed on 2nd Reading' && 
+          action.vote.data.count.Y < 55) {
+        
+        console.log(`Fixing House blast motion for ${bill.identifier}: ${actionData.id}`);
+        // Force override to enforce 55-vote constitutional majority requirement
+        action.vote.data.motionPassed = false;
+      }
+    });
+  });
+  
 // const recapOutput = new RecapPage({ actions: actionsFlat, bills, updateTime }).export()
 
 const keyBillCategoryKeys = Array.from(new Set(billAnnotations.map(d => d.category))).filter(d => d !== null).filter(d => d !== undefined)

--- a/process/models/Vote.js
+++ b/process/models/Vote.js
@@ -124,7 +124,12 @@ export default class Vote {
         throw `classifyMotionThreshold failed, ${voteType}, ${billVoteMajorityRequired}`
     }
 
-    didMotionPass = (count, threshold, billStartingChamber, voteChamber) => {
+    didMotionPass = (count, threshold, billStartingChamber, voteChamber, motion) => {
+        // Special case for House blast motions
+        if (voteChamber === 'house' && 
+            motion === 'Taken from Committee; Placed on 2nd Reading') {
+            return (count.Y >= 55); // constitutional majority required — senate is just bare majority
+        }
         const isVoteInFirstChamber = (billStartingChamber === voteChamber)
         if (threshold === 'simple') {
             return (count.Y > count.N)

--- a/process/models/Vote.js
+++ b/process/models/Vote.js
@@ -124,12 +124,7 @@ export default class Vote {
         throw `classifyMotionThreshold failed, ${voteType}, ${billVoteMajorityRequired}`
     }
 
-    didMotionPass = (count, threshold, billStartingChamber, voteChamber, motion) => {
-        // Special case for House blast motions
-        if (voteChamber === 'house' && 
-            motion === 'Taken from Committee; Placed on 2nd Reading') {
-            return (count.Y >= 55); // constitutional majority required — senate is just bare majority
-        }
+    didMotionPass = (count, threshold, billStartingChamber, voteChamber) => {
         const isVoteInFirstChamber = (billStartingChamber === voteChamber)
         if (threshold === 'simple') {
             return (count.Y > count.N)


### PR DESCRIPTION
**In this PR**
1) Handle the house blast motions not showing the proper vote threshold (passing at majority — needs 55)