### PR TITLE
Fix excessive memory consumption on certain pages

### DIFF
--- a/process/main.js
+++ b/process/main.js
@@ -195,11 +195,19 @@ const actionsOutput = bills.map(b => ({
 
 // Breaking this into chunks to avoid too-large-for-github-files
 const chunkSize = 200
-let index = 1
+let index = 1;
 for (let start = 0; start < actionsOutput.length; start += chunkSize) {
     writeJson(`./src/data/bill-actions-${index}.json`, actionsOutput.slice(start, start + chunkSize))
-    index += 1
+    index += 1;
 }
+
+// Write individual files per bill:
+if (!fs.existsSync('./src/data/bills')) {
+    fs.mkdirSync('./src/data/bills', { recursive: true });
+}
+actionsOutput.forEach(billActions => {
+    writeJson(`./src/data/bills/${billActions.bill.replace(' ', '-')}-actions.json`, billActions.actions);
+});
 
 writeJson('./src/data/bills.json', billsOutput)
 

--- a/process/main.js
+++ b/process/main.js
@@ -1,4 +1,5 @@
 import { getJson, collectJsons, writeJson, getYaml, collectYamls, getText, getCsv } from './utils.js'
+import fs from 'fs'
 
 import Lawmaker from './models/Lawmaker.js'
 import Bill from './models/Bill.js'
@@ -193,14 +194,17 @@ const actionsOutput = bills.map(b => ({
     actions: b.exportActionDataWithVotes()
 }))
 
-// Breaking this into chunks to avoid too-large-for-github-files
-const chunkSize = 200
-let index = 1;
-for (let start = 0; start < actionsOutput.length; start += chunkSize) {
-    writeJson(`./src/data/bill-actions-${index}.json`, actionsOutput.slice(start, start + chunkSize))
-    index += 1;
-}
+// Old chunking method for actions
 
+// Breaking this into chunks to avoid too-large-for-github-files
+// const chunkSize = 200
+// let index = 1;
+// for (let start = 0; start < actionsOutput.length; start += chunkSize) {
+//     writeJson(`./src/data/bill-actions-${index}.json`, actionsOutput.slice(start, start + chunkSize))
+//     index += 1;
+// }
+
+// Memory optimization so we don't have to load entire bill page
 // Write individual files per bill:
 if (!fs.existsSync('./src/data/bills')) {
     fs.mkdirSync('./src/data/bills', { recursive: true });

--- a/server.js
+++ b/server.js
@@ -1,18 +1,39 @@
 const express = require('express');
 const path = require('path');
+const fs = require('fs');
 const app = express();
 const port = 3000;
 
+const basePath = '/capitol-tracker-2025';
+const buildPath = path.join(__dirname, 'build');
+
+// Log requests
 app.use((req, res, next) => {
     console.log(`Request URL: ${req.url}`);
     next();
 });
 
-app.use('/capitol-tracker-2025/_next', express.static(path.join(__dirname, 'build/_next')));
-app.use(express.static(path.join(__dirname, 'build')));
+// Serve _next assets
+app.use(`${basePath}/_next`, express.static(path.join(buildPath, '_next')));
 
-app.get('*', (req, res) => {
-    res.sendFile(path.join(__dirname, 'build', 'index.html'));
+// Serve static files (JS, CSS, etc.)
+app.use(basePath, express.static(buildPath));
+
+// Fallback route
+app.get(`${basePath}/*`, (req, res) => {
+    // Remove basePath from URL
+    const relativePath = req.path.replace(basePath, '') || '/';
+    const filePath = path.join(buildPath, relativePath);
+
+    // Try to serve a file directly
+    fs.stat(filePath, (err, stats) => {
+        if (!err && stats.isFile()) {
+            res.sendFile(filePath);
+        } else {
+            // Fallback to index.html for client-side routing
+            res.sendFile(path.join(buildPath, 'index.html'));
+        }
+    });
 });
 
 app.listen(port, () => {

--- a/src/components/BillTable.js
+++ b/src/components/BillTable.js
@@ -21,6 +21,9 @@ const BillTable = ({ bills, suppressCount, sortFunction = DEFAULT_SORT, displayL
     };
 
     loadBillsWithAmendments();
+    return () => {
+      isMounted = false;
+    };
   }, []);
 
   const toggleDisplayLimit = () => {
@@ -215,13 +218,13 @@ const Bill = ({ title, identifier, chamber, status, explanation, textUrl, fiscal
             )}
             {/* Only show amendments link if bill is in the amendments list */}
             {hasAmendments && (
-                <a
-                  css={billLinkCss}
-                  href="#"
-                  onClick={handleOpenAmendmentsModal}
-                >
-                  🖍 Proposed amendments
-                </a>
+              <a
+                css={billLinkCss}
+                href="#"
+                onClick={handleOpenAmendmentsModal}
+              >
+                🖍 Proposed amendments
+              </a>
             )}
             {vetoMemoUrl && <a css={billLinkCss} href={vetoMemoUrl} target="_blank" rel="noopener noreferrer">🚫 Veto memo</a>}
             {(numArticles > 0) && (

--- a/src/pages/bill-cards/[key].js
+++ b/src/pages/bill-cards/[key].js
@@ -32,27 +32,21 @@ export async function getStaticProps({ params }) {
 }
 
 async function loadBillActions(billId) {
-    const dataDir = path.join(process.cwd(), 'src/data');
-    const files = await fs.readdir(dataDir);
-    const actionFiles = files.filter(
-        (file) => file.startsWith('bill-actions-') && file.endsWith('.json')
-    );
-
-    let allActions = [];
-
-    for (const file of actionFiles) {
-        const filePath = path.join(dataDir, file);
-        const fileContent = await fs.readFile(filePath, 'utf8');
-        const actionsChunk = JSON.parse(fileContent);
-        const billActions = actionsChunk.find((item) => item.bill === billId);
-        if (billActions) {
-            allActions = billActions.actions;
-            break;
-        }
+    try {
+      // Normalize bill ID format (e.g., "HB 123" -> "HB-123")
+      const normalizedBillId = billId.replace(' ', '-');
+      
+      // Construct direct path to this specific bill's actions file
+      const filePath = path.join(process.cwd(), 'src/data/bills', `${normalizedBillId}-actions.json`);
+      
+      // Read and parse the file
+      const fileContent = await fs.readFile(filePath, 'utf8');
+      return JSON.parse(fileContent);
+    } catch (error) {
+      console.error(`Error loading actions for ${billId}:`, error);
+      return [];
     }
-
-    return allActions;
-}
+  }
 
 const Bill = ({ bill }) => {
     if (!bill) return <div>Bill not found</div>;

--- a/src/pages/bills/[key].js
+++ b/src/pages/bills/[key].js
@@ -30,25 +30,17 @@ export async function getStaticProps({ params }) {
     };
 }
 
+// for new indivudual bill-actions
 async function loadBillActions(billId) {
-    const dataDir = path.join(process.cwd(), 'src/data');
-    const files = await fs.readdir(dataDir);
-    const actionFiles = files.filter(file => file.startsWith('bill-actions-') && file.endsWith('.json'));
-
-    let allActions = [];
-
-    for (const file of actionFiles) {
-        const filePath = path.join(dataDir, file);
-        const fileContent = await fs.readFile(filePath, 'utf8');
-        const actionsChunk = JSON.parse(fileContent);
-        const billActions = actionsChunk.find(item => item.bill === billId);
-        if (billActions) {
-            allActions = billActions.actions;
-            break;
-        }
-    }
-
-    return allActions;
+  try {
+    const normalizedBillId = billId.replace(' ', '-');
+    const filePath = path.join(process.cwd(), 'src/data/bills', `${normalizedBillId}-actions.json`);
+    const fileContent = await fs.readFile(filePath, 'utf8');
+    return JSON.parse(fileContent);
+  } catch (error) {
+    console.error(`Error loading actions for ${billId}:`, error);
+    return [];
+  }
 }
 
 const Bill = ({ bill }) => {


### PR DESCRIPTION
**In this PR**
1) `process/main.js` now outputs a file for each bill
2) loadBillActions in `bill-cards` and `bills pages` now uses the single file for each bill. (Memory usage reduced from over 300MB to less than 50MB)
3) Modifications to reduce memory usage in `all-bills` from upwards of 1GB at times to around 250MB (there's a lot of bills)
4) `server.js` file runs the built version of the website properly now. Had some weird page issues before. Allowing for accurate debugging of a production build. 