### PR TITLE
Fix Bills displaying improperly post session

### DIFF
--- a/.github/workflows/data.yml
+++ b/.github/workflows/data.yml
@@ -5,7 +5,10 @@ on:
     branches:
       - main
   schedule:
-    - cron: '*/20 12-23,0-5 * * *'
+    # post session, run every hour since action is much lower
+    - cron: '0 12-23,0-5 * * *'
+    # During session, every 20 minutes from 12:00 to 05:59 UTC
+    # - cron: '*/20 12-23,0-5 * * *'
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Capitol Tracker 2025
 
-TODO: UPDATE THIS 
+## Make sure to set the end date for the session in `/process/config/session.js`

--- a/process/config/procedure.js
+++ b/process/config/procedure.js
@@ -1,3 +1,5 @@
+## procedure.js
+
 export const VOTE_THRESHOLD_MAPPING = {
     'TWO_THIRDS_LEGISLATURE': '2/3 of Entire Legislature',
     'THREE_FOURTHS': '3/4 of Each House',
@@ -218,6 +220,7 @@ export const ACTIONS = [
     { key: 'Committee Executive Action--Bill Passed as Amended', isMajor, isHighlight, committeeAction, advanced, amended },
     { key: 'Committee Executive Action--Bill Not Passed', isMajor, isHighlight, committeeAction, failed },
     { key: 'Committee Executive Action--Bill Not Passed as Amended', isMajor, isHighlight, committeeAction, failed },
+    {key: 'Committee Report--Bill Passed', isMajor, isHighlight, committeeAction, advanced },
     // second chamber committee actions
     { key: 'Committee Executive Action--Bill Concurred', isMajor, isHighlight, committeeAction, advanced, },
     { key: 'Committee Executive Action--Bill Concurred as Amended', isMajor, isHighlight, committeeAction, advanced, amended },

--- a/process/config/procedure.js
+++ b/process/config/procedure.js
@@ -291,9 +291,9 @@ export const ACTIONS = [
     { key: "2nd Reading Governor's Proposed Amendments Not Adopt Motion Failed", isMajor, floorDebate, reconciliationAction },
 
     { key: '3rd Reading Passed as Amended by House', isMajor, isHighlight, reconciliationAction, advanced },
-    { key: '3rd Reading Not Passed as Amended by House', isMajor, isHighlight, reconciliationAction, },
+    { key: '3rd Reading Not Passed as Amended by House', isMajor, isHighlight, reconciliationAction, failed},
     { key: '3rd Reading Passed as Amended by Senate', isMajor, isHighlight, reconciliationAction, advanced },
-    { key: '3rd Reading Not Passed as Amended by Senate', isMajor, isHighlight, reconciliationAction, },
+    { key: '3rd Reading Not Passed as Amended by Senate', isMajor, isHighlight, reconciliationAction, failed},
 
     { key: '3rd Reading Conference Committee Report Adopted', isMajor, reconciliationAction, advanced },
     { key: '3rd Reading Conference Committee Report Rejected', isMajor, reconciliationAction },

--- a/process/config/procedure.js
+++ b/process/config/procedure.js
@@ -291,9 +291,9 @@ export const ACTIONS = [
     { key: "2nd Reading Governor's Proposed Amendments Not Adopt Motion Failed", isMajor, floorDebate, reconciliationAction },
 
     { key: '3rd Reading Passed as Amended by House', isMajor, isHighlight, reconciliationAction, advanced },
-    { key: '3rd Reading Not Passed as Amended by House', isMajor, isHighlight, reconciliationAction, advanced },
+    { key: '3rd Reading Not Passed as Amended by House', isMajor, isHighlight, reconciliationAction, },
     { key: '3rd Reading Passed as Amended by Senate', isMajor, isHighlight, reconciliationAction, advanced },
-    { key: '3rd Reading Not Passed as Amended by Senate', isMajor, isHighlight, reconciliationAction, advanced },
+    { key: '3rd Reading Not Passed as Amended by Senate', isMajor, isHighlight, reconciliationAction, },
 
     { key: '3rd Reading Conference Committee Report Adopted', isMajor, reconciliationAction, advanced },
     { key: '3rd Reading Conference Committee Report Rejected', isMajor, reconciliationAction },

--- a/process/config/procedure.js
+++ b/process/config/procedure.js
@@ -1,5 +1,3 @@
-## procedure.js
-
 export const VOTE_THRESHOLD_MAPPING = {
     'TWO_THIRDS_LEGISLATURE': '2/3 of Entire Legislature',
     'THREE_FOURTHS': '3/4 of Each House',

--- a/process/config/session.js
+++ b/process/config/session.js
@@ -1,0 +1,1 @@
+export const SESSION_END_DATE = '2025-04-30'; // YYYY-MM-DD

--- a/process/models/Bill.js
+++ b/process/models/Bill.js
@@ -2,6 +2,7 @@ import Action from './Action.js'
 
 import { MANUAL_SIGNINGS, MANUAL_VETOS } from '../config/overrides.js'
 import { BILL_TYPES, VOTE_THRESHOLDS, VOTE_THRESHOLD_MAPPING, BILL_STATUSES } from '../config/procedure.js'
+import { SESSION_END_DATE } from '../config/session.js'
 import { capitalize } from '../functions.js'
 
 import {
@@ -13,6 +14,8 @@ import {
     // firstActionWithFlag,
     // lastActionWithFlag
 } from '../functions.js'
+
+const sessionEndDate = timeParse('%Y-%m-%d')(SESSION_END_DATE);
 
 export default class Bill {
     constructor({
@@ -386,6 +389,20 @@ export default class Bill {
                 }
             }
         })
+        const now = new Date();
+        if (now > sessionEndDate) {
+            progressionSteps.forEach(step => {
+                // Only override if not at governor or already law
+                if (
+                    (step.status === 'current' || step.status === 'future') &&
+                    step.step !== 'governor' &&
+                    step.statusLabel !== 'Became law'
+                ) {
+                    step.status = 'blocked';
+                    step.statusLabel = 'Failed (session ended)';
+                }
+            });
+        }
         return progressionSteps
     }
 

--- a/process/models/Bill.js
+++ b/process/models/Bill.js
@@ -4,6 +4,7 @@ import { MANUAL_SIGNINGS, MANUAL_VETOS } from '../config/overrides.js'
 import { BILL_TYPES, VOTE_THRESHOLDS, VOTE_THRESHOLD_MAPPING, BILL_STATUSES } from '../config/procedure.js'
 import { SESSION_END_DATE } from '../config/session.js'
 import { capitalize } from '../functions.js'
+import { timeParse } from 'd3-time-format'
 
 import {
     billKey,
@@ -251,6 +252,16 @@ export default class Bill {
                     statusLabel = 'Pending'
                 }
 
+                const failedBlast = committeeActionsInFirstChamber.find(
+                    a => a.key === 'Taken from Committee; Placed on 2nd Reading' && a.vote && a.vote.motionPassed === false
+                );
+                if (failedBlast) {
+                    status = 'blocked';
+                    statusLabel = 'Blast motion failed';
+                    statusDate = failedBlast.date;
+                    return { step, status, statusLabel, statusDate };
+                }
+
                 if (committeeActionsInFirstChamber.length === 0) {
                     return { step, status, statusLabel, statusDate }
                 } else {
@@ -322,13 +333,13 @@ export default class Bill {
                     //  Fix for HB-337 (maybe others)
                     if (lastFloorAction.finalPassage && progressFlagInActions(secondChamberActions, 'amended')) {
                         // Look for explicit "returned with amendments" actions that indicate formal reconciliation
-                        const needsReconciliation = actions.some(a => 
+                        const needsReconciliation = actions.some(a =>
                             a.description && (
-                                a.description.includes("Returned to House with Amendments") || 
+                                a.description.includes("Returned to House with Amendments") ||
                                 a.description.includes("Returned to Senate with Amendments")
                             )
                         );
-                        
+
                         reconciliationNecessary = needsReconciliation;
                     }
                     statusDate = lastFloorAction.date
@@ -391,19 +402,124 @@ export default class Bill {
         })
         const now = new Date();
         if (now > sessionEndDate) {
-            progressionSteps.forEach(step => {
-                // Only override if not at governor or already law
+            // find committee step
+            const committeeStepIdx = progressionSteps.findIndex(s => s.step === 'first committee');
+            let committeeStepWasBlast = false;
+            if (committeeStepIdx !== -1) {
+                const committeeStep = progressionSteps[committeeStepIdx];
+                const lastCommitteeAction = committeeActionsInFirstCommittee.slice(-1)[0];
+
+                // if last committee action is a blast motion and it's pending (no vote or not passed)
                 if (
-                    (step.status === 'current' || step.status === 'future') &&
-                    step.step !== 'governor' &&
-                    step.statusLabel !== 'Became law'
+                    lastCommitteeAction &&
+                    lastCommitteeAction.key === 'Taken from Table in Committee' &&
+                    (!lastCommitteeAction.vote || lastCommitteeAction.vote.motionPassed === false)
                 ) {
-                    step.status = 'blocked';
-                    step.statusLabel = 'Failed (session ended)';
+                    committeeStep.status = 'blocked';
+                    committeeStep.statusLabel = 'Blast motion not taken up';
+                    committeeStepWasBlast = true;
                 }
-            });
+            }
+
+            // only mark the last pending step as failed if it's not the committee step,
+            // and only if the committee step wasn't just marked as a failed blast
+            let blockedFound = false;
+            for (let i = 0; i < progressionSteps.length; i++) {
+                if (blockedFound) {
+                    progressionSteps[i].status = 'future';
+                    progressionSteps[i].statusLabel = null;
+                    progressionSteps[i].statusDate = null;
+                }
+                if (progressionSteps[i].status === 'blocked') {
+                    blockedFound = true;
+                }
+            }
+            const firstCommitteeIdx = progressionSteps.findIndex(s => s.step === 'first committee');
+            const billUltimatelyPassed = actions.some(a => a.ultimatelyPassed);
+
+            if (
+                firstCommitteeIdx !== -1 &&
+                progressionSteps[firstCommitteeIdx].status === 'current' &&
+                !billUltimatelyPassed
+            ) {
+                progressionSteps[firstCommitteeIdx].status = 'blocked';
+                progressionSteps[firstCommitteeIdx].statusLabel = 'No committee action before deadline';
+            }
+            const firstChamberIdx = progressionSteps.findIndex(
+                s => s.step === 'first chamber' && (s.status === 'current' || s.status === 'future')
+            );
+            const anyBlockedBeforeFirst = progressionSteps.slice(0, firstChamberIdx).some(s => s.status === 'blocked');
+            const committeePassed = firstCommitteeIdx !== -1 && progressionSteps[firstCommitteeIdx].status === 'passed';
+            if (
+                firstChamberIdx !== -1 &&
+                !anyBlockedBeforeFirst &&
+                committeePassed &&
+                !billUltimatelyPassed
+            ) {
+                progressionSteps[firstChamberIdx].status = 'blocked';
+                progressionSteps[firstChamberIdx].statusLabel = `Failed in ${capitalize(firstChamber)}`;
+            }
+
+            // only mark second chamber as failed if first chamber is passed
+            const secondChamberIdx = progressionSteps.findIndex(
+                s => s.step === 'second chamber' && (s.status === 'current' || s.status === 'future')
+            );
+            const anyBlockedBeforeSecond = progressionSteps.slice(0, secondChamberIdx).some(s => s.status === 'blocked');
+            const hasTransmittedToSecondChamber = actions.some(a =>
+                a.key === `Transmitted to ${capitalize(secondChamber)}`
+            );
+            if (
+                secondChamberIdx !== -1 &&
+                !anyBlockedBeforeSecond &&
+                hasTransmittedToSecondChamber
+            ) {
+                const secondChamberName = (firstChamber === 'house') ? 'Senate' : 'House';
+                progressionSteps[secondChamberIdx].status = 'blocked';
+                progressionSteps[secondChamberIdx].statusLabel = `Failed in ${secondChamberName}`;
+            }
+
+            //  use hasReachedGovernor for all governor/reconciliation logic
+            const reconciliationIdx = progressionSteps.findIndex(s => s.step === 'reconciliation');
+            if (
+                reconciliationIdx !== -1 &&
+                hasReachedGovernor &&
+                progressionSteps[reconciliationIdx].status !== 'passed'
+            ) {
+                progressionSteps[reconciliationIdx].status = 'skipped';
+                progressionSteps[reconciliationIdx].statusLabel = 'Not required';
+            }
+            // only mark as failed if there is no blocked step before it
+            const anyBlockedBeforeReconciliation = progressionSteps.slice(0, reconciliationIdx).some(s => s.status === 'blocked');
+            if (
+                reconciliationIdx !== -1 &&
+                !anyBlockedBeforeReconciliation &&
+                progressionSteps[reconciliationIdx].status !== 'skipped' &&
+                progressionSteps[reconciliationIdx].status !== 'passed'
+            ) {
+                progressionSteps[reconciliationIdx].status = 'blocked';
+                progressionSteps[reconciliationIdx].statusLabel = 'No agreement between chambers';
+            }
         }
-        return progressionSteps
+
+        const billUltimatelyPassed = actions.some(a => a.ultimatelyPassed);
+        const firstChamberIdx = progressionSteps.findIndex(s => s.step === 'first chamber');
+        const secondChamberIdx = progressionSteps.findIndex(s => s.step === 'second chamber');
+        const reconciliationIdx = progressionSteps.findIndex(s => s.step === 'reconciliation');
+
+        // if the bill reached the governor or ultimately passed, force both chambers to "passed"
+        if ((hasReachedGovernor || billUltimatelyPassed) && firstChamberIdx !== -1) {
+            progressionSteps[firstChamberIdx].status = 'passed';
+            progressionSteps[firstChamberIdx].statusLabel = `Passed ${capitalize(firstChamber)}`;
+        }
+        if ((hasReachedGovernor || billUltimatelyPassed) && secondChamberIdx !== -1) {
+            progressionSteps[secondChamberIdx].status = 'passed';
+            progressionSteps[secondChamberIdx].statusLabel = `Passed ${capitalize(secondChamber)}`;
+        }
+        if ((hasReachedGovernor || billUltimatelyPassed) && reconciliationIdx !== -1) {
+            progressionSteps[reconciliationIdx].status = 'skipped';
+            progressionSteps[reconciliationIdx].statusLabel = 'Not required';
+        }
+        return progressionSteps;
     }
 
     getVoteMajorityRequired = (voteRequirements) => {


### PR DESCRIPTION
**In this PR**
1) Add processing to handle post-session cleanup in `Bills.js`
2) Add/modify a few entries in `procedure.js` to compliment 
3) Add a `SESSION_END_DATE` to `/process/config/session.js` to tell processing when it is time for session end cleanup to occur
4) Added entry in `README.md` about `SESSION_END_DATE` so it doesn't cause issues for next session because the end date is nearly 2 years ago 
5) Modify GitHub Actions to run once an hour rather than every 20 minutes since the session is over — just waiting for gov to sign stuff